### PR TITLE
Publicly imported hFILE

### DIFF
--- a/source/dhtslib/htslib/hts.d
+++ b/source/dhtslib/htslib/hts.d
@@ -48,7 +48,8 @@ import dhtslib.htslib.bgzf;
 /// see cram.h, sam.h, sam.d
 struct cram_fd; // @suppress(dscanner.style.phobos_naming_convention)
 /// see hfile.d
-struct hFILE; // @suppress(dscanner.style.phobos_naming_convention)
+//struct hFILE; // @suppress(dscanner.style.phobos_naming_convention)
+public import dhtslib.htslib.hfile:hFILE;
 /// see thread_pool.d
 struct hts_tpool; // @suppress(dscanner.style.phobos_naming_convention)
 


### PR DESCRIPTION
Received this error reguarding the SAMWriter ctor. It seems that we have two different hFILE structs. I have changed hts.d to use the hFILE struct in hfile.d instead of an opaque struct.
```
dhtslib/source/dhtslib/sam.d(1115,32): Error: function dhtslib.htslib.hts.hts_hopen(hFILE* fp,
 const(char)* fn, const(char)* mode) is not callable using argument types (hFILE*, immutable(char)*, char*)
dhtslib/source/dhtslib/sam.d(1115,32):        cannot pass argument this.f of type
 dhtslib.htslib.hfile.hFILE* to parameter dhtslib.htslib.hts.hFILE* fp
```
https://github.com/blachlylab/dhtslib/blob/4b2389370d8bdeed9f36841d6779cf5a27ce2e2e/source/dhtslib/sam.d#L1109-L1116