### PR TITLE
Cigar and md changes

### DIFF
--- a/source/dhtslib/package.d
+++ b/source/dhtslib/package.d
@@ -1,7 +1,7 @@
 module dhtslib;
 
 public import dhtslib.bgzf;
-public import dhtslib.cigar;
+public import dhtslib.sam.cigar;
 public import dhtslib.faidx;
 public import dhtslib.sam;
 public import dhtslib.tabix;

--- a/source/dhtslib/sam/cigar.d
+++ b/source/dhtslib/sam/cigar.d
@@ -10,6 +10,7 @@ import std.algorithm : map;
 import std.algorithm.iteration : each;
 import std.conv : to;
 import std.range : array;
+import std.traits : isIntegral;
 
 import htslib.hts_log;
 import dhtslib.sam : SAMRecord;
@@ -86,24 +87,30 @@ struct Cigar
 
         return result;
     }
+    
+    /// Get a Slice of cigar ops from a range in the Cigar string
+    auto opSlice(T)(T start, T end) if (isIntegral!T)
+    {
+        return ops[start .. end];
+    }
 
-    ref CigarOp opIndex(ulong i){
+    /// Get a cigar op from a single position in the Cigar string
+    ref auto opIndex(ulong i)
+    {
         return ops[i];
     }
 
-    CigarOp[] opIndex(size_t[2] range){
-        return ops[range[0] .. range[1]];
-    }
-
-    CigarOp opIndexAssign(CigarOp value, size_t index)
+    /// Assign a cigar op at a single position in the Cigar string
+    auto opIndexAssign(CigarOp value, size_t index)
     {
         return ops[index] = value;
     }
 
-    CigarOp[] opIndexAssign(CigarOp[] values, size_t[2] indexes)
+    /// Assign a range cigar ops over a range in the Cigar string
+    auto opSliceAssign(T)(CigarOp[] values, T start, T end)
     {
-        assert(indexes[1] - indexes[0] == values.length);
-        return ops[indexes[0] .. indexes[1]] = values;
+        assert(end - start == values.length);
+        return ops[start .. end] = values;
     }
 }
 
@@ -206,7 +213,7 @@ debug (dhtslib_unittest) unittest
     hts_set_log_level(htsLogLevel.HTS_LOG_TRACE);
     hts_log_info(__FUNCTION__, "Testing cigar");
     hts_log_info(__FUNCTION__, "Loading test file");
-    auto bam = SAMFile(buildPath(dirName(dirName(dirName(__FILE__))), "htslib",
+    auto bam = SAMFile(buildPath(dirName(dirName(dirName(dirName(__FILE__)))), "htslib",
             "test", "range.bam"), 0);
     auto readrange = bam["CHROMOSOME_I", 914];
     hts_log_info(__FUNCTION__, "Getting read 1");
@@ -216,6 +223,11 @@ debug (dhtslib_unittest) unittest
     hts_log_info(__FUNCTION__, "Cigar:" ~ cigar.toString());
     writeln(cigar.toString());
     assert(cigar.toString() == "78M1D22M");
+    assert(cigar[0] == CigarOp(78, Ops.MATCH));
+    assert(Cigar(cigar[0 .. 2]).toString == "78M1D");
+    cigar[0] = CigarOp(4,Ops.HARD_CLIP);
+    cigar[1..3] = [CigarOp(2, Ops.INS), CigarOp(21, Ops.MATCH)];
+    assert(cigar.toString() == "4H2I21M");
 }
 
 /// return Cigar struct for a given CIGAR string (e.g. from SAM line)
@@ -355,7 +367,7 @@ debug (dhtslib_unittest) unittest
     hts_set_log_level(htsLogLevel.HTS_LOG_TRACE);
     hts_log_info(__FUNCTION__, "Testing cigar");
     hts_log_info(__FUNCTION__, "Loading test file");
-    auto bam = SAMFile(buildPath(dirName(dirName(dirName(__FILE__))), "htslib",
+    auto bam = SAMFile(buildPath(dirName(dirName(dirName(dirName(__FILE__)))), "htslib",
             "test", "range.bam"), 0);
     auto readrange = bam["CHROMOSOME_I", 914];
     hts_log_info(__FUNCTION__, "Getting read 1");

--- a/source/dhtslib/sam/cigar.d
+++ b/source/dhtslib/sam/cigar.d
@@ -24,13 +24,13 @@ struct Cigar
     /// Construct Cigar from raw data
     this(uint* cigar, uint length)
     {
-        ops = (cast(CigarOp*) cigar)[0 .. length];
+        ops = (cast(CigarOp*) cigar)[0 .. length].dup;
     }
 
     /// Construct Cigar from an array of CIGAR ops
     this(CigarOp[] ops)
     {
-        this.ops = ops;
+        this.ops = ops.dup;
     }
 
     bool is_null()
@@ -85,6 +85,25 @@ struct Cigar
         }
 
         return result;
+    }
+
+    ref CigarOp opIndex(ulong i){
+        return ops[i];
+    }
+
+    CigarOp[] opIndex(size_t[2] range){
+        return ops[range[0] .. range[1]];
+    }
+
+    CigarOp opIndexAssign(CigarOp value, size_t index)
+    {
+        return ops[index] = value;
+    }
+
+    CigarOp[] opIndexAssign(CigarOp[] values, size_t[2] indexes)
+    {
+        assert(indexes[1] - indexes[0] == values.length);
+        return ops[indexes[0] .. indexes[1]] = values;
     }
 }
 

--- a/source/dhtslib/sam/cigar.d
+++ b/source/dhtslib/sam/cigar.d
@@ -1,7 +1,7 @@
 /**
 This module simplifies working with CIGAR strings/ops from SAM/BAM/CRAM alignment records.
 */
-module dhtslib.cigar;
+module dhtslib.sam.cigar;
 
 import std.stdio;
 import std.bitmanip : bitfields;

--- a/source/dhtslib/sam/cigar.d
+++ b/source/dhtslib/sam/cigar.d
@@ -25,13 +25,13 @@ struct Cigar
     /// Construct Cigar from raw data
     this(uint* cigar, uint length)
     {
-        ops = (cast(CigarOp*) cigar)[0 .. length].dup;
+        ops = (cast(CigarOp*) cigar)[0 .. length];
     }
 
     /// Construct Cigar from an array of CIGAR ops
     this(CigarOp[] ops)
     {
-        this.ops = ops.dup;
+        this.ops = ops;
     }
 
     bool is_null()

--- a/source/dhtslib/sam/md.d
+++ b/source/dhtslib/sam/md.d
@@ -11,7 +11,7 @@ Reference: https://samtools.github.io/hts-specs/SAMtags.pdf
 module dhtslib.sam.md;
 
 import dhtslib.sam : SAMRecord;
-import dhtslib.cigar;
+import dhtslib.sam.cigar;
 import htslib.hts_log;
 import std.regex;
 import std.traits : ReturnType;
@@ -152,7 +152,7 @@ debug (dhtslib_unittest) unittest
     import std.array : array;
     import std.path : buildPath, dirName;
 
-    auto bam = SAMFile(buildPath(dirName(dirName(dirName(__FILE__))), "htslib",
+    auto bam = SAMFile(buildPath(dirName(dirName(dirName(dirName(__FILE__)))), "htslib",
             "test", "range.bam"), 0);
     auto read = bam.all_records.front;
     read["MD"] = "2G11^GATC7T6^A11";

--- a/source/dhtslib/sam/md.d
+++ b/source/dhtslib/sam/md.d
@@ -8,7 +8,7 @@ This can enable variant calling without require access to the entire original re
 
 Reference: https://samtools.github.io/hts-specs/SAMtags.pdf
 */
-module dhtslib.md;
+module dhtslib.sam.md;
 
 import dhtslib.sam : SAMRecord;
 import dhtslib.cigar;

--- a/source/dhtslib/sam/package.d
+++ b/source/dhtslib/sam/package.d
@@ -49,7 +49,7 @@ import htslib.hfile : hdopen, hclose, hFILE;
 import htslib.hts_log;
 import htslib.kstring;
 import htslib.sam;
-import dhtslib.cigar;
+import dhtslib.sam.cigar;
 import dhtslib.tagvalue;
 
 /**
@@ -502,7 +502,7 @@ class SAMRecord
     /// range is 0-based half open using chromosomal coordinates
     auto getAlignedPairs(bool withRefSeq)(long start, long end)
     {
-        import dhtslib.md : MDItr;
+        import dhtslib.sam.md : MDItr;
         import std.range : dropExactly;
         struct AlignedPairs(bool refSeq)
         {
@@ -709,7 +709,7 @@ debug(dhtslib_unittest) unittest
 {
     import std.stdio;
     import dhtslib.sam;
-    import dhtslib.md : MDItr;
+    import dhtslib.sam.md : MDItr;
     import std.algorithm: map;
     import std.array: array;
     import std.path:buildPath,dirName;


### PR DESCRIPTION
Pull request for discussion of changes.
```md.d``` and ```cigar.d``` pulled under ```dhtslib.sam```
Can now use ```opIndex``` and ```opSlice``` for indexing and assignment with ```Cigar``` struct directly.
Should fix #40 by adding dups in ctors. If ctor is used, Cigar struct should own the cigar string data.
Any other changes to be made?