### PR TITLE
apt-get update github actions

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Install htslib deps
         run: |
-            sudo apt-get install -y build-essential autoconf zlib1g-dev libbz2-dev liblzma-dev libcurl4-openssl-dev libssl-dev
+            sudo apt-get update && sudo apt-get install -y build-essential autoconf zlib1g-dev libbz2-dev liblzma-dev libcurl4-openssl-dev libssl-dev
 
       - name: Get htslib commit
         id: get-htslib-commit


### PR DESCRIPTION
apt-cache on the github actions VM was stale and some packages failed to install in ubuntu-latest.
`sudo apt-get update && ` added before package install