### PR TITLE
Coordinate system improvements

### DIFF
--- a/source/dhtslib/bed/package.d
+++ b/source/dhtslib/bed/package.d
@@ -86,9 +86,10 @@ debug(dhtslib_unittest) unittest
     hts_log_info(__FUNCTION__, "Testing BedReader (Tabix)");
     hts_log_info(__FUNCTION__, "Loading test file");
     
+    auto reg = getIntervalFromString("X:1000-1400");
     auto bed = BedReader(
         buildPath(dirName(dirName(dirName(dirName(__FILE__)))),"htslib","test","tabix","bed_file.bed.gz"),
-        ChromZBHO("X:1000-1400")
+        reg.contig, reg.interval
         );
 
     assert(bed.array.length == 2);

--- a/source/dhtslib/bed/package.d
+++ b/source/dhtslib/bed/package.d
@@ -88,7 +88,7 @@ debug(dhtslib_unittest) unittest
     
     auto bed = BedReader(
         buildPath(dirName(dirName(dirName(dirName(__FILE__)))),"htslib","test","tabix","bed_file.bed.gz"),
-        ZBHO("X:1000-1400")
+        ChromZBHO("X:1000-1400")
         );
 
     assert(bed.array.length == 2);

--- a/source/dhtslib/bed/reader.d
+++ b/source/dhtslib/bed/reader.d
@@ -11,14 +11,8 @@ auto BedReader(string fn)
     return RecordReader!BedRecord(fn);
 }
 
-/// returns a BedRecord range from a RecordReaderRegion
-auto BedReader(CoordSystem cs)(string fn, ChromCoordinates!cs region, string fnIdx = "")
-{
-    return RecordReaderRegion!(BedRecord, cs)(fn, region, fnIdx);
-}
-
 /// ditto
-auto BedReader(CoordSystem cs)(string fn, string chrom, Coordinates!cs coords, string fnIdx = "")
+auto BedReader(CoordSystem cs)(string fn, string chrom, Interval!cs coords, string fnIdx = "")
 {
     return RecordReaderRegion!(BedRecord, cs)(fn, chrom, coords, fnIdx);
 }

--- a/source/dhtslib/bed/record.d
+++ b/source/dhtslib/bed/record.d
@@ -76,7 +76,7 @@ struct BedRecord
     /// column 2: The starting position of the feature in the chromosome or scaffold.
     /// column 3: The ending position of the feature in the chromosome or scaffold. 
     /// setter
-    @property coordinates(CoordSystem cs)(Coordinates!cs coords)
+    @property coordinates(CoordSystem cs)(Interval!cs coords)
     {
         unpack;
         if(this.fields.length < 3) this.fields.length = 3;

--- a/source/dhtslib/coordinates.d
+++ b/source/dhtslib/coordinates.d
@@ -88,6 +88,17 @@ struct Coordinate(Basis bs)
         else static assert(0, "Coordinate Type error");
     }
 
+    /// Convert coordinate to another based system using shortcuts
+    auto to(T: ZB)()
+    {
+        return this.to!(Basis.zero);
+    }
+
+    auto to(T: OB)()
+    {
+        return this.to!(Basis.one);
+    }
+
     /// make a new coordinate with a value of this.pos + off
     /// this.pos + off
     auto offset(T)(T off)
@@ -260,6 +271,30 @@ struct Coordinates(CoordSystem cs)
         }
     }
 
+    /// Convert coordinate to another based system using shortcuts
+    auto to(T: ZBHO)()
+    {
+        return this.to!(CoordSystem.zbho);
+    }
+
+    /// Convert coordinate to another based system using shortcuts
+    auto to(T: OBHO)()
+    {
+        return this.to!(CoordSystem.obho);
+    }
+
+    /// Convert coordinate to another based system using shortcuts
+    auto to(T: ZBC)()
+    {
+        return this.to!(CoordSystem.zbc);
+    }
+    
+    /// Convert coordinate to another based system using shortcuts
+    auto to(T: OBC)()
+    {
+        return this.to!(CoordSystem.obc);
+    }
+
     /// make a new coordinate pair with a value of 
     /// this.start + off and this.end + off
     auto offset(T)(T off)
@@ -377,6 +412,30 @@ struct ChromCoordinates(CoordSystem cs)
         return c;
     }
 
+    /// Convert coordinate to another based system using shortcuts
+    auto to(T: ZBHO)()
+    {
+        return this.to!(CoordSystem.zbho);
+    }
+
+    /// Convert coordinate to another based system using shortcuts
+    auto to(T: OBHO)()
+    {
+        return this.to!(CoordSystem.obho);
+    }
+
+    /// Convert coordinate to another based system using shortcuts
+    auto to(T: ZBC)()
+    {
+        return this.to!(CoordSystem.zbc);
+    }
+    
+    /// Convert coordinate to another based system using shortcuts
+    auto to(T: OBC)()
+    {
+        return this.to!(CoordSystem.obc);
+    }
+
     /// Get string representation for printing
     string toString() const{
         return "[" ~ CoordSystemLabels[cs] ~ "] " ~ 
@@ -455,13 +514,30 @@ debug(dhtslib_unittest) unittest
 debug(dhtslib_unittest) unittest
 {
     import std.stdio;
-    auto c0 = Coordinates!(CoordSystem.zbho)(ZB(0), ZB(100));
+    auto c0 = Coordinates!(CoordSystem.zbho)(0, 100);
     assert(c0.size == 100);
 
     auto c1 = c0.to!(CoordSystem.zbc);
     auto c2 = c0.to!(CoordSystem.obc);
     auto c3 = c0.to!(CoordSystem.obho);
     auto c4 = c0.to!(CoordSystem.zbho);
+    
+    assert(c1 == ZBC(0, 99));
+    assert(c2 == OBC(1, 100));
+    assert(c3 == OBHO(1, 101));
+    assert(c4 == ZBHO(0, 100));
+}
+
+debug(dhtslib_unittest) unittest
+{
+    import std.stdio;
+    auto c0 = ZBHO(0, 100);
+    assert(c0.size == 100);
+
+    auto c1 = c0.to!ZBC;
+    auto c2 = c0.to!OBC;
+    auto c3 = c0.to!OBHO;
+    auto c4 = c0.to!ZBHO;
     
     assert(c1 == ZBC(0, 99));
     assert(c2 == OBC(1, 100));

--- a/source/dhtslib/coordinates.d
+++ b/source/dhtslib/coordinates.d
@@ -312,101 +312,26 @@ struct ChromCoordinates(CoordSystem cs)
     } 
 }
 
-/// Shortcut string ZBHO
-auto ZeroBasedHalfOpen(T: string)(T region)
-{
-    return ChromCoordinates!(CoordSystem.zbho)(region);
-}
+alias ZBHO = Coordinates!(CoordSystem.zbho);
+alias OBHO = Coordinates!(CoordSystem.obho);
+alias ZBC = Coordinates!(CoordSystem.zbc);
+alias OBC = Coordinates!(CoordSystem.obc);
 
-/// Shortcut long ZBHO
-auto ZeroBasedHalfOpen(T: long)(T start, T end)
-{
-    return Coordinates!(CoordSystem.zbho)(start, end);
-}
+alias ZeroBasedHalfOpen = Coordinates!(CoordSystem.zbho);
+alias OneBasedHalfOpen = Coordinates!(CoordSystem.obho);
+alias ZeroBasedClosed = Coordinates!(CoordSystem.zbc);
+alias OneBasedClosed = Coordinates!(CoordSystem.obc);
 
-/// Shortcut string ZBHO
-auto ZBHO(T: string)(T region)
-{
-    return ChromCoordinates!(CoordSystem.zbho)(region);
-}
+alias ChromZBHO = ChromCoordinates!(CoordSystem.zbho);
+alias ChromOBHO = ChromCoordinates!(CoordSystem.obho);
+alias ChromZBC = ChromCoordinates!(CoordSystem.zbc);
+alias ChromOBC = ChromCoordinates!(CoordSystem.obc);
 
-/// Shortcut long ZBHO
-auto ZBHO(T: long)(T start, T end)
-{
-    return Coordinates!(CoordSystem.zbho)(start, end);
-}
+alias ChromZeroBasedHalfOpen = ChromCoordinates!(CoordSystem.zbho);
+alias ChromOneBasedHalfOpen = ChromCoordinates!(CoordSystem.obho);
+alias ChromZeroBasedClosed = ChromCoordinates!(CoordSystem.zbc);
+alias ChromOneBasedClosed = ChromCoordinates!(CoordSystem.obc);
 
-/// Shortcut string ZBC
-auto ZeroBasedClosed(T: string)(T region)
-{
-    return ChromCoordinates!(CoordSystem.zbc)(region);
-}
-
-/// Shortcut long ZBC
-auto ZeroBasedClosed(T: long)(T start, T end)
-{
-    return Coordinates!(CoordSystem.zbc)(start, end);
-}
-
-/// Shortcut string ZBC
-auto ZBC(T: string)(T region)
-{
-    return ChromCoordinates!(CoordSystem.zbc)(region);
-}
-
-/// Shortcut long ZBC
-auto ZBC(T: long)(T start, T end)
-{
-    return Coordinates!(CoordSystem.zbc)(start, end);
-}
-
-/// Shortcut string OBHO
-auto OneBasedHalfOpen(T: string)(T region)
-{
-    return ChromCoordinates!(CoordSystem.obho)(region);
-}
-
-/// Shortcut long OBHO
-auto OneBasedHalfOpen(T: long)(T start, T end)
-{
-    return Coordinates!(CoordSystem.obho)(start, end);
-}
-
-/// Shortcut string OBHO
-auto OBHO(T: string)(T region)
-{
-    return ChromCoordinates!(CoordSystem.obho)(region);
-}
-
-/// Shortcut long OBHO
-auto OBHO(T: long)(T start, T end)
-{
-    return Coordinates!(CoordSystem.obho)(start, end);
-}
-
-/// Shortcut string OBC
-auto OneBasedClosed(T: string)(T region)
-{
-    return ChromCoordinates!(CoordSystem.obc)(region);
-}
-
-/// Shortcut long OBC
-auto OneBasedClosed(T: long)(T start, T end)
-{
-    return Coordinates!(CoordSystem.obc)(start, end);
-}
-
-/// Shortcut string OBC
-auto OBC(T: string)(T region)
-{
-    return ChromCoordinates!(CoordSystem.obc)(region);
-}
-
-/// Shortcut long OBC
-auto OBC(T: long)(T start, T end)
-{
-    return Coordinates!(CoordSystem.obc)(start, end);
-}
 
 debug(dhtslib_unittest) unittest
 {
@@ -442,10 +367,10 @@ debug(dhtslib_unittest) unittest
     auto c3 = c0.to!(CoordSystem.obho);
     auto c4 = c0.to!(CoordSystem.zbho);
     
-    assert(c1 == ZBC("chrom1:0-99"));
-    assert(c2 == OBC("chrom1:1-100"));
-    assert(c3 == OBHO("chrom1:1-101"));
-    assert(c4 == ZBHO("chrom1:0-100"));
+    assert(c1 == ChromZBC("chrom1:0-99"));
+    assert(c2 == ChromOBC("chrom1:1-100"));
+    assert(c3 == ChromOBHO("chrom1:1-101"));
+    assert(c4 == ChromZBHO("chrom1:0-100"));
     
     writeln(c0);
     writeln(c1);

--- a/source/dhtslib/coordinates.d
+++ b/source/dhtslib/coordinates.d
@@ -195,12 +195,6 @@ struct Coordinates(CoordSystem cs)
         this.end.pos = end;
     }
 
-    /// Coordinate constructor
-    this(Coordinate!basetype start, Coordinate!basetype end){
-        this.start = start;
-        this.end = end;
-    }
-
     invariant
     {
         // In half-open systems, ensure start strictly less than end,
@@ -398,7 +392,7 @@ debug(dhtslib_unittest) unittest
 
 debug(dhtslib_unittest) unittest
 {
-    auto c0 = Coordinates!(CoordSystem.obho)(OB(1), OB(101));
+    auto c0 = Coordinates!(CoordSystem.obho)(1, 101);
     assert(c0.size == 100);
 
     auto c1 = c0.to!(CoordSystem.zbc);

--- a/source/dhtslib/coordinates.d
+++ b/source/dhtslib/coordinates.d
@@ -534,20 +534,20 @@ debug(dhtslib_unittest) unittest
 }
 
 ///
-debug(dhtslib_unittest) unittest
-{
-    import dhtslib.sam;
-    import htslib.hts_log;
-    import std.path : buildPath, dirName;
-    import std.string : fromStringz;
-    import std.array : array; 
+// debug(dhtslib_unittest) unittest
+// {
+//     import dhtslib.sam;
+//     import htslib.hts_log;
+//     import std.path : buildPath, dirName;
+//     import std.string : fromStringz;
+//     import std.array : array; 
 
-    hts_set_log_level(htsLogLevel.HTS_LOG_WARNING);
-    hts_log_info(__FUNCTION__, "Testing SAMFile & SAMRecord");
-    hts_log_info(__FUNCTION__, "Loading test file");
-    auto sam = SAMFile(buildPath(dirName(dirName(dirName(dirName(__FILE__)))),"htslib","test","auxf#values.sam"), 0);
+//     hts_set_log_level(htsLogLevel.HTS_LOG_WARNING);
+//     hts_log_info(__FUNCTION__, "Testing SAMFile & SAMRecord");
+//     hts_log_info(__FUNCTION__, "Loading test file");
+//     auto sam = SAMFile(buildPath(dirName(dirName(dirName(dirName(__FILE__)))),"htslib","test","auxf#values.sam"), 0);
     
-    auto reg = getIntervalFromString("sheila:1-10",sam.header);
-    assert(reg.tid == 0);
-    assert(reg.interval == ZBHO(0,11));
-}
+//     auto reg = getIntervalFromString("sheila:1-10",sam.header);
+//     assert(reg.tid == 0);
+//     assert(reg.interval == ZBHO(0,11));
+// }

--- a/source/dhtslib/faidx.d
+++ b/source/dhtslib/faidx.d
@@ -229,10 +229,10 @@ debug(dhtslib_unittest) unittest
     writeln(fai["CHROMOSOME_I",OB(1) .. OB(30)]);
     assert(fai["CHROMOSOME_I",OB(1) .. OB(30)] == "GCCTAAGCCTAAGCCTAAGCCTAAGCCTA");
     
-    assert(fai.fetchSequence(ZBHO("CHROMOSOME_I:0-29")) == "GCCTAAGCCTAAGCCTAAGCCTAAGCCTA");
-    assert(fai.fetchSequence(OBHO("CHROMOSOME_I:1-30")) == "GCCTAAGCCTAAGCCTAAGCCTAAGCCTA");
-    assert(fai.fetchSequence(ZBC("CHROMOSOME_I:0-28")) == "GCCTAAGCCTAAGCCTAAGCCTAAGCCTA");
-    assert(fai.fetchSequence(OBC("CHROMOSOME_I:1-29")) == "GCCTAAGCCTAAGCCTAAGCCTAAGCCTA");
+    assert(fai.fetchSequence(ChromZBHO("CHROMOSOME_I:0-29")) == "GCCTAAGCCTAAGCCTAAGCCTAAGCCTA");
+    assert(fai.fetchSequence(ChromOBHO("CHROMOSOME_I:1-30")) == "GCCTAAGCCTAAGCCTAAGCCTAAGCCTA");
+    assert(fai.fetchSequence(ChromZBC("CHROMOSOME_I:0-28")) == "GCCTAAGCCTAAGCCTAAGCCTAAGCCTA");
+    assert(fai.fetchSequence(ChromOBC("CHROMOSOME_I:1-29")) == "GCCTAAGCCTAAGCCTAAGCCTAAGCCTA");
 
     assert(fai.seqLen("CHROMOSOME_I") == 1009800);
     assert(fai.nSeq == 7);

--- a/source/dhtslib/faidx.d
+++ b/source/dhtslib/faidx.d
@@ -101,7 +101,7 @@ struct IndexedFastaFile {
 
     /// Fetch sequence in region by assoc array-style lookup:
     /// `string sequence = fafile["chr2:20123-30456"]`
-    auto opIndex(CoordSystem cs)(ChromCoordinates!cs region)
+    auto opIndex(CoordSystem cs)(ChromInterval!cs region)
     {
         return fetchSequence(region);
     }
@@ -110,7 +110,7 @@ struct IndexedFastaFile {
     /// `string sequence = fafile["chr2", 20123 .. 30456]`
     ///
     /// Sadly, $ to represent max length is not supported
-    auto opIndex(CoordSystem cs)(string contig, Coordinates!cs coords)
+    auto opIndex(CoordSystem cs)(string contig, Interval!cs coords)
     {
         return fetchSequence(contig, coords);
     }
@@ -120,21 +120,13 @@ struct IndexedFastaFile {
     in { assert(start >= 0); assert(start <= end); }
     do
     {
-        auto coords = Coordinates!(getCoordinateSystem!(bs, End.open))(start, end);
+        auto coords = Interval!(getCoordinateSystem!(bs, End.open))(start, end);
         return coords;
-    }
-
-    /// Fetch sequence in region by assoc array-style lookup:
-    /// `string sequence = fafile.fetchSequence("chr2:20123-30456")`
-
-    string fetchSequence(CoordSystem cs)(ChromCoordinates!cs region)
-    {
-        return fetchSequence(region.chrom, region.coords);
     }
 
     /// Fetch sequencing in a region by function call with contig, start, end
     /// `string sequence = fafile.fetchSequence("chr2", 20123, 30456)`
-    string fetchSequence(CoordSystem cs)(string contig, Coordinates!cs coords)
+    string fetchSequence(CoordSystem cs)(string contig, Interval!cs coords)
     {
         char *fetchedSeq;
         long fetchedLen;
@@ -228,11 +220,6 @@ debug(dhtslib_unittest) unittest
     import std.stdio;
     writeln(fai["CHROMOSOME_I",OB(1) .. OB(30)]);
     assert(fai["CHROMOSOME_I",OB(1) .. OB(30)] == "GCCTAAGCCTAAGCCTAAGCCTAAGCCTA");
-    
-    assert(fai.fetchSequence(ChromZBHO("CHROMOSOME_I:0-29")) == "GCCTAAGCCTAAGCCTAAGCCTAAGCCTA");
-    assert(fai.fetchSequence(ChromOBHO("CHROMOSOME_I:1-30")) == "GCCTAAGCCTAAGCCTAAGCCTAAGCCTA");
-    assert(fai.fetchSequence(ChromZBC("CHROMOSOME_I:0-28")) == "GCCTAAGCCTAAGCCTAAGCCTAAGCCTA");
-    assert(fai.fetchSequence(ChromOBC("CHROMOSOME_I:1-29")) == "GCCTAAGCCTAAGCCTAAGCCTAAGCCTA");
 
     assert(fai.seqLen("CHROMOSOME_I") == 1009800);
     assert(fai.nSeq == 7);

--- a/source/dhtslib/gff/reader.d
+++ b/source/dhtslib/gff/reader.d
@@ -122,7 +122,7 @@ debug(dhtslib_unittest) unittest
     
     auto gff = GFF3Reader(
         buildPath(dirName(dirName(dirName(dirName(__FILE__)))),"htslib","test","tabix","gff_file.gff.gz"),
-        OBC("X:2934832-2935190")
+        ChromOBC("X:2934832-2935190")
         );
 
     assert(gff.array.length == 4);

--- a/source/dhtslib/gff/reader.d
+++ b/source/dhtslib/gff/reader.d
@@ -13,14 +13,8 @@ auto GFF3Reader(string fn)
     return RecordReader!GFF3Record(fn);
 }
 
-/// Returns a RecordReaderRegion range for a GFF3 file
-auto GFF3Reader(CoordSystem cs)(string fn, ChromCoordinates!cs region, string fnIdx = "")
-{
-    return RecordReaderRegion!(GFF3Record, cs)(fn, region, fnIdx);
-}
-
 /// ditto
-auto GFF3Reader(CoordSystem cs)(string fn, string chrom, Coordinates!cs coords, string fnIdx = "")
+auto GFF3Reader(CoordSystem cs)(string fn, string chrom, Interval!cs coords, string fnIdx = "")
 {
     return RecordReaderRegion!(GFF3Record, cs)(fn, chrom, coords, fnIdx);
 }
@@ -31,14 +25,8 @@ auto GTFReader(string fn)
     return RecordReader!GTFRecord(fn);
 }
 
-/// Returns a RecordReaderRegion range for a GTF file
-auto GTFReader(CoordSystem cs)(string fn, ChromCoordinates!cs region, string fnIdx = "")
-{
-    return RecordReaderRegion!(GTFRecord, cs)(fn, region, fnIdx);
-}
-
 /// ditto
-auto GTFReader(CoordSystem cs)(string fn, string chrom, Coordinates!cs coords, string fnIdx = "")
+auto GTFReader(CoordSystem cs)(string fn, string chrom, Interval!cs coords, string fnIdx = "")
 {
     return RecordReaderRegion!(GTFRecord, cs)(fn, chrom, coords, fnIdx);
 }
@@ -49,14 +37,8 @@ auto GFF2Reader(string fn)
     return RecordReader!GTFRecord(fn);
 }
 
-/// Returns a RecordReaderRegion range for a GFF2 file
-auto GFF2Reader(CoordSystem cs)(string fn, ChromCoordinates!cs region, string fnIdx = "")
-{
-    return RecordReaderRegion!(GTFRecord, cs)(fn, region, fnIdx);
-}
-
 /// ditto
-auto GFF2Reader(CoordSystem cs)(string fn, string chrom, Coordinates!cs coords, string fnIdx = "")
+auto GFF2Reader(CoordSystem cs)(string fn, string chrom, Interval!cs coords, string fnIdx = "")
 {
     return RecordReaderRegion!(GTFRecord, cs)(fn, chrom, coords, fnIdx);
 }
@@ -120,9 +102,10 @@ debug(dhtslib_unittest) unittest
     // writeln(err);
     hts_log_info(__FUNCTION__, "Loading test file");
     
+    auto reg = getIntervalFromString("X:2934832-2935190");
     auto gff = GFF3Reader(
         buildPath(dirName(dirName(dirName(dirName(__FILE__)))),"htslib","test","tabix","gff_file.gff.gz"),
-        ChromOBC("X:2934832-2935190")
+        reg.contig, reg.interval
         );
 
     assert(gff.array.length == 4);

--- a/source/dhtslib/gff/record.d
+++ b/source/dhtslib/gff/record.d
@@ -181,7 +181,7 @@ struct GFFRecord(GFFVersion ver)
 
     /// Columns 4 & 5: returns Coordinate set: OBC format
     /// setter
-    @property coordinates(CoordSystem cs)(Coordinates!cs coords)
+    @property coordinates(CoordSystem cs)(Interval!cs coords)
     {
         unpack;
         auto newCoords = coords.to!(CoordSystem.obc);

--- a/source/dhtslib/sam/reader.d
+++ b/source/dhtslib/sam/reader.d
@@ -247,7 +247,7 @@ struct SAMReader
     *   auto reads6 = bamfile.query("{HLA-DRB1*12:17}:1-100");
     *   ```
     */ 
-    auto query(CoordSystem cs)(string chrom, Coordinates!cs coords)
+    auto query(CoordSystem cs)(string chrom, Interval!cs coords)
     in (!this.header.isNull)
     {
         auto tid = this.header.targetId(chrom);
@@ -255,7 +255,7 @@ struct SAMReader
     }
 
     /// ditto
-    auto query(CoordSystem cs)(int tid, Coordinates!cs coords)
+    auto query(CoordSystem cs)(int tid, Interval!cs coords)
     in (!this.header.isNull)
     {
         /// convert to zero-based half-open
@@ -265,7 +265,7 @@ struct SAMReader
     }
 
     /// ditto
-    auto query(CoordSystem cs)(ChromCoordinates!cs region)
+    auto query(CoordSystem cs)(ChromInterval!cs region)
     in (!this.header.isNull)
     {
         return query(region.chrom, region.coords);
@@ -279,25 +279,19 @@ struct SAMReader
     }
 
     /// ditto
-    auto opIndex(CoordSystem cs)(ChromCoordinates!cs region)
-    {
-        return query!cs(region);
-    }
-
-    /// ditto
     auto opIndex(string[] regions)
     {
         return query(regions);
     }
 
     /// ditto
-    auto opIndex(CoordSystem cs)(string tid, Coordinates!cs coords)
+    auto opIndex(CoordSystem cs)(string tid, Interval!cs coords)
     {
         return query(tid, coords);
     }
 
     /// ditto
-    auto opIndex(CoordSystem cs)(int tid, Coordinates!cs coords)
+    auto opIndex(CoordSystem cs)(int tid, Interval!cs coords)
     {
         return query(tid, coords);
     }
@@ -305,14 +299,14 @@ struct SAMReader
     /// ditto
     auto opIndex(Basis bs)(string tid, Coordinate!bs pos)
     {
-        auto coords = Coordinates!(getCoordinateSystem!(bs,End.open))(pos, pos + 1);
+        auto coords = Interval!(getCoordinateSystem!(bs,End.open))(pos, pos + 1);
         return query(tid, coords);
     }
 
     /// ditto
     auto opIndex(Basis bs)(int tid, Coordinate!bs pos)
     {
-        auto coords = Coordinates!(getCoordinateSystem!(bs,End.open))(pos, pos + 1);
+        auto coords = Interval!(getCoordinateSystem!(bs,End.open))(pos, pos + 1);
         return query(tid, coords);
     }
 
@@ -320,7 +314,7 @@ struct SAMReader
     deprecated("use multidimensional slicing with second parameter as range ([\"chr1\", 1 .. 2])")
     auto opIndex(Basis bs)(string tid, Coordinate!bs pos1, Coordinate!bs pos2)
     {
-        auto coords = Coordinates!(getCoordinateSystem!(bs,End.open))(pos1, pos2);
+        auto coords = Interval!(getCoordinateSystem!(bs,End.open))(pos1, pos2);
         return query(tid, coords);
     }
 
@@ -328,7 +322,7 @@ struct SAMReader
     deprecated("use multidimensional slicing with second parameter as range ([20, 1 .. 2])")
     auto opIndex(Basis bs)(int tid, Coordinate!bs pos1, Coordinate!bs pos2)
     {
-        auto coords = Coordinates!(getCoordinateSystem!(bs,End.open))(pos1, pos2);
+        auto coords = Interval!(getCoordinateSystem!(bs,End.open))(pos1, pos2);
         return query(tid, coords);
     }
 
@@ -336,7 +330,7 @@ struct SAMReader
     auto opSlice(size_t dim, Basis bs)(Coordinate!bs start, Coordinate!bs end) if(dim == 1)
     {
         assert(end > start);
-        return Coordinates!(getCoordinateSystem!(bs, End.open))(start, end);
+        return Interval!(getCoordinateSystem!(bs, End.open))(start, end);
     }
 
 
@@ -372,7 +366,7 @@ struct SAMReader
         auto tid = this.header.targetId(ctg);
         auto end = this.header.targetLength(tid) + endoff.offset;
         // TODO review: is targetLength the last nt, or targetLength - 1 the last nt?
-        auto coords = Coordinates!(CoordSystem.zbho)(end, end + 1);
+        auto coords = Interval!(CoordSystem.zbho)(end, end + 1);
         return query(tid, coords);
     }
     /// ditto
@@ -380,7 +374,7 @@ struct SAMReader
     {
         auto end = this.header.targetLength(tid) + endoff.offset;
         // TODO review: is targetLength the last nt, or targetLength - 1 the last nt?
-        auto coords = Coordinates!(CoordSystem.zbho)(end, end + 1);
+        auto coords = Interval!(CoordSystem.zbho)(end, end + 1);
         return query(tid, coords);
     }
     /// ditto
@@ -395,7 +389,7 @@ struct SAMReader
         auto end = this.header.targetLength(tid) + coords[1];
         auto endCoord = ZB(end);
         auto newEndCoord = endCoord.to!bs;
-        auto c = Coordinates!(getCoordinateSystem!(bs,End.open))(coords[0], newEndCoord);
+        auto c = Interval!(getCoordinateSystem!(bs,End.open))(coords[0], newEndCoord);
         return query(tid, c);
     }
     /// ditto
@@ -404,7 +398,7 @@ struct SAMReader
         auto end = this.header.targetLength(tid) + coords[1];
         auto endCoord = ZB(end);
         auto newEndCoord = endCoord.to!bs;
-        auto c = Coordinates!(getCoordinateSystem!(bs,End.open))(coords[0], newEndCoord);
+        auto c = Interval!(getCoordinateSystem!(bs,End.open))(coords[0], newEndCoord);
         return query(tid, c);
     }
 
@@ -819,7 +813,6 @@ debug(dhtslib_unittest) unittest
     // assert(bam["CHROMOSOME_III"].array.length == 41);
     // assert(bam["CHROMOSOME_IV"].array.length == 19);
     // assert(bam["CHROMOSOME_V"].array.length == 0);
-    assert(bam.query(ChromOBC("CHROMOSOME_I:900-2000")).array.length == 14);
     assert(bam.query("CHROMOSOME_I", ZBHO(900, 2000)) .array.length == 14);
     assert(bam["CHROMOSOME_I",ZB(900) .. ZB(2000)].array.length == 14);
     assert(bam[0, ZB(900) .. ZB(2000)].array.length == 14);
@@ -834,7 +827,6 @@ debug(dhtslib_unittest) unittest
     assert(bam[0, $].array.length == 0);
     assert(bam[["CHROMOSOME_I:900-2000","CHROMOSOME_II:900-2000"]].array.length == 33);
 
-    assert(bam.query(ChromOBC("CHROMOSOME_I:900-2000")).array.length == 14);
     assert(bam.query("CHROMOSOME_I", OBHO(901, 2000)) .array.length == 14);
     assert(bam["CHROMOSOME_I",OB(901) .. OB(2001)].array.length == 14);
     assert(bam[0, OB(901) .. OB(2001)].array.length == 14);

--- a/source/dhtslib/sam/reader.d
+++ b/source/dhtslib/sam/reader.d
@@ -819,7 +819,7 @@ debug(dhtslib_unittest) unittest
     // assert(bam["CHROMOSOME_III"].array.length == 41);
     // assert(bam["CHROMOSOME_IV"].array.length == 19);
     // assert(bam["CHROMOSOME_V"].array.length == 0);
-    assert(bam.query(OBC("CHROMOSOME_I:900-2000")).array.length == 14);
+    assert(bam.query(ChromOBC("CHROMOSOME_I:900-2000")).array.length == 14);
     assert(bam.query("CHROMOSOME_I", ZBHO(900, 2000)) .array.length == 14);
     assert(bam["CHROMOSOME_I",ZB(900) .. ZB(2000)].array.length == 14);
     assert(bam[0, ZB(900) .. ZB(2000)].array.length == 14);
@@ -834,7 +834,7 @@ debug(dhtslib_unittest) unittest
     assert(bam[0, $].array.length == 0);
     assert(bam[["CHROMOSOME_I:900-2000","CHROMOSOME_II:900-2000"]].array.length == 33);
 
-    assert(bam.query(OBC("CHROMOSOME_I:900-2000")).array.length == 14);
+    assert(bam.query(ChromOBC("CHROMOSOME_I:900-2000")).array.length == 14);
     assert(bam.query("CHROMOSOME_I", OBHO(901, 2000)) .array.length == 14);
     assert(bam["CHROMOSOME_I",OB(901) .. OB(2001)].array.length == 14);
     assert(bam[0, OB(901) .. OB(2001)].array.length == 14);

--- a/source/dhtslib/sam/reader.d
+++ b/source/dhtslib/sam/reader.d
@@ -264,12 +264,6 @@ struct SAMReader
         return RecordRange(this.fp, this.header, itr);
     }
 
-    /// ditto
-    auto query(CoordSystem cs)(ChromInterval!cs region)
-    in (!this.header.isNull)
-    {
-        return query(region.chrom, region.coords);
-    }
 
     /// ditto
     auto query(string[] regions)

--- a/source/dhtslib/sam/record.d
+++ b/source/dhtslib/sam/record.d
@@ -99,18 +99,18 @@ struct SAMRecord
     /// 0-based leftmost coordinate
     pragma(inline, true)
     @nogc @safe nothrow
-    @property Coordinate!(Basis.zero) pos() { return Coordinate!(Basis.zero)(this.b.core.pos); }
+    @property ZB pos() { return ZB(this.b.core.pos); }
     /// ditto
     pragma(inline, true)
     @nogc @safe nothrow
-    @property void pos(Coordinate!(Basis.zero) pos) { this.b.core.pos = pos.pos; }
+    @property void pos(ZB pos) { this.b.core.pos = pos.pos; }
 
     /// 0-based, half-open coordinates that represent
     /// the mapped length of the alignment 
     pragma(inline, true)
-    @property Coordinates!(CoordSystem.zbho) coordinates()
+    @property ZBHO coordinates()
     {
-        return Coordinates!(CoordSystem.zbho)(this.pos, this.pos + this.cigar.alignedLength);
+        return ZBHO(this.pos, this.pos + this.cigar.alignedLength);
     }
 
     // TODO: @field  bin     bin calculated by bam_reg2bin()

--- a/source/dhtslib/vcf/reader.d
+++ b/source/dhtslib/vcf/reader.d
@@ -245,9 +245,9 @@ debug(dhtslib_unittest) unittest
     hts_log_info(__FUNCTION__, "Loading test file");
     auto fn = buildPath(dirName(dirName(dirName(dirName(__FILE__)))),"htslib","test","tabix","vcf_file.vcf.gz");
     auto tbx = TabixIndexedFile(fn);
-    auto vcf = VCFReader(tbx, OBHO("1:3000151-3062916"));
+    auto vcf = VCFReader(tbx, ChromOBHO("1:3000151-3062916"));
     assert(vcf.count == 3);
-    vcf = VCFReader(tbx, OBHO("1:3000151-3062916"));
+    vcf = VCFReader(tbx, ChromOBHO("1:3000151-3062916"));
     vcf.empty;
     VCFRecord rec = vcf.front;
     assert(rec.chrom == "1");

--- a/source/dhtslib/vcf/reader.d
+++ b/source/dhtslib/vcf/reader.d
@@ -19,9 +19,9 @@ auto VCFReader(string fn, int MAX_UNPACK = BCF_UN_ALL)
     return VCFReaderImpl!(CoordSystem.zbc, false)(fn, MAX_UNPACK);
 }
 
-auto VCFReader(CoordSystem cs)(TabixIndexedFile tbxFile, ChromCoordinates!cs region, int MAX_UNPACK = BCF_UN_ALL)
+auto VCFReader(CoordSystem cs)(TabixIndexedFile tbxFile, string chrom, Interval!cs coords, int MAX_UNPACK = BCF_UN_ALL)
 {
-    return VCFReaderImpl!(cs,true)(tbxFile, region, MAX_UNPACK);
+    return VCFReaderImpl!(cs,true)(tbxFile, chrom, coords, MAX_UNPACK);
 }
 
 /** Basic support for reading VCF, BCF files */
@@ -47,10 +47,10 @@ struct VCFReaderImpl(CoordSystem cs, bool isTabixFile)
         ReturnType!(this.initializeTabixRange) tbxRange; /// For tabix use
 
         /// TabixIndexedFile and coordinates ctor
-        this(TabixIndexedFile tbxFile, ChromCoordinates!cs region, int MAX_UNPACK = BCF_UN_ALL)
+        this(TabixIndexedFile tbxFile, string chrom, Interval!cs coords, int MAX_UNPACK = BCF_UN_ALL)
         {
             this.tbx = tbxFile;
-            this.tbxRange = initializeTabixRange(region);
+            this.tbxRange = initializeTabixRange(chrom, coords);
             this.tbxRange.empty;
             /// read the header from TabixIndexedFile
             bcf_hdr_t * hdrPtr = bcf_hdr_init(toUTFz!(char *)("r"));
@@ -63,9 +63,9 @@ struct VCFReaderImpl(CoordSystem cs, bool isTabixFile)
         }
 
         /// copy the TabixIndexedFile.region range
-        auto initializeTabixRange(ChromCoordinates!cs region)
+        auto initializeTabixRange(string chrom, Interval!cs coords)
         {
-            return this.tbx.region(region);
+            return this.tbx.region(chrom, coords);
         }
     }else{
         /// read existing VCF file
@@ -245,9 +245,10 @@ debug(dhtslib_unittest) unittest
     hts_log_info(__FUNCTION__, "Loading test file");
     auto fn = buildPath(dirName(dirName(dirName(dirName(__FILE__)))),"htslib","test","tabix","vcf_file.vcf.gz");
     auto tbx = TabixIndexedFile(fn);
-    auto vcf = VCFReader(tbx, ChromOBHO("1:3000151-3062916"));
+    auto reg = getIntervalFromString("1:3000151-3062916");
+    auto vcf = VCFReader(tbx, reg.contig, reg.interval);
     assert(vcf.count == 3);
-    vcf = VCFReader(tbx, ChromOBHO("1:3000151-3062916"));
+    vcf = VCFReader(tbx, reg.contig, reg.interval);
     vcf.empty;
     VCFRecord rec = vcf.front;
     assert(rec.chrom == "1");

--- a/source/dhtslib/vcf/record.d
+++ b/source/dhtslib/vcf/record.d
@@ -180,16 +180,16 @@ struct VCFRecord
      * NB: internally BCF is uzing 0 based coordinates; we only show +1 when printing a VCF line with toString (which calls vcf_format)
     */
     @property
-    Coordinate!(Basis.zero) pos()
+    ZB pos()
     out(coord) { assert(coord >= 0); }
     do
     {
         if (!this.line.unpacked) bcf_unpack(this.line, BCF_UN_STR);
-        return Coordinate!(Basis.zero)(this.line.pos);
+        return ZB(this.line.pos);
     }
     /// Set position (POS, column 2)
     @property
-    void pos(Coordinate!(Basis.zero) p)
+    void pos(ZB p)
     in { assert(p >= 0); }
     do
     {
@@ -246,9 +246,9 @@ struct VCFRecord
     }
 
     /// Coordinate range of the reference allele
-    @property Coordinates!(CoordSystem.zbho) coordinates()
+    @property ZBHO coordinates()
     {
-        return Coordinates!(CoordSystem.zbho)(this.pos, this.pos + this.refLen);
+        return ZBHO(this.pos, this.pos + this.refLen);
     }
     
     /// All alleles getter (array)


### PR DESCRIPTION
Fixes #81, #82, #85.
-  shortform names are no longer functions they are just aliases
   - allows this `ZBHO val = ZBHO(1, 0);`
   - `ChromCoordinates` shortcuts are of form: `ChromZBHO`
- added functions for calculating intersection and union of two `Coordinates`.
- Can now use shortform for conversion `OBC newVal = val.to!OBC;`