### PR TITLE
VCF Overhaul

### DIFF
--- a/source/dhtslib/vcf/header.d
+++ b/source/dhtslib/vcf/header.d
@@ -313,6 +313,12 @@ struct VCFHeader
     pragma(inline, true)
     @property int nsamples() { return bcf_hdr_nsamples(this.hdr); }
 
+    int getSampleId(string sam){
+        auto ret = bcf_hdr_id2int(this.hdr, HeaderDictTypes.SAMPLE, toUTFz!(char *)(sam));
+        if(ret == -1) hts_log_error(__FUNCTION__, "Couldn't find sample in header: " ~ sam);
+        return ret;
+    }
+
     // TODO
     /// copy header lines from a template without overwiting existing lines
     void copyHeaderLines(bcf_hdr_t *other)

--- a/source/dhtslib/vcf/header.d
+++ b/source/dhtslib/vcf/header.d
@@ -14,16 +14,20 @@ import htslib.vcf;
 import htslib.hts_log;
 
 
-
+/// Struct for easy setting and getting of hrec values for VCFheader
 struct HeaderRecord
 {
     /// HeaderRecordType type i.e INFO, contig, FORMAT
     HeaderRecordType recType = HeaderRecordType.NULL;
 
     /// string of HeaderRecordType type i.e INFO, contig, FORMAT ?
+    /// or could be ##source=program
+    ///               ======
     string key;
 
-    /// mostly empty ?
+    /// mostly empty except for
+    /// this ##source=program
+    ///               =======
     string value;
 
     /// number kv pairs
@@ -220,6 +224,7 @@ struct HeaderRecord
         vals~=value;
     }
 
+    /// convert to bcf_hrec_t for use with htslib functions
     bcf_hrec_t * convert(bcf_hdr_t * hdr)
     {
         if(this.recType == HeaderRecordType.INFO || this.recType == HeaderRecordType.FORMAT){
@@ -468,6 +473,7 @@ struct VCFHeader
         addHeaderLine!(HeaderRecordType.FILTER)(id, description);
     }
 
+    /// string representation of header
     string toString(){
         import htslib.kstring;
         kstring_t s;

--- a/source/dhtslib/vcf/header.d
+++ b/source/dhtslib/vcf/header.d
@@ -57,9 +57,9 @@ enum HDR_LENGTH_STRINGS = ["FIXED",".","A","G","R"];
 /// Replacement for htslib BCF_DT_*
 enum HDR_DICT_TYPE
 {
-    BCF_DT_ID =     0, /// dictionary type: ID
-    BCF_DT_CTG =    1, /// dictionary type: CONTIG
-    BCF_DT_SAMPLE = 2, /// dictionary type: SAMPLE
+    ID =     0, /// dictionary type: ID
+    CTG =    1, /// dictionary type: CONTIG
+    SAMPLE = 2, /// dictionary type: SAMPLE
 }
 
 struct HeaderRecord

--- a/source/dhtslib/vcf/header.d
+++ b/source/dhtslib/vcf/header.d
@@ -263,7 +263,7 @@ struct HeaderRecord
             }
         }
         this.nkeys++;
-        keys~=key;
+        keys~=index;
         vals~=value;
     }
 

--- a/source/dhtslib/vcf/package.d
+++ b/source/dhtslib/vcf/package.d
@@ -19,7 +19,7 @@ enum HeaderRecordType
     GENERIC =   5, /// header line: generic header line
 }
 
-/// Strings for HDR_LINE
+/// Strings for HeaderRecordType
 static immutable HeaderRecordTypeStrings = ["FILTER","INFO","FORMAT","contig", "struct", "generic"];
 
 /// Replacement for htslib BCF_HT_*
@@ -35,7 +35,7 @@ enum HeaderTypes
     LONG =  INT | 0x100, // BCF_HT_INT, but for int64_t values; VCF only!
 }
 
-/// Strings for HDR_TYPE
+/// Strings for HeaderTypes
 static immutable HeaderTypesStrings = ["Flag","Integer","Float","String","Character","Long"];
 
 /// Replacement for htslib BCF_VL_*
@@ -61,7 +61,8 @@ enum HeaderDictTypes
 }
 
 /// Replacement for htslib BCF_BT_*
-enum RecordType{
+enum RecordType
+{
     NULL =   0,  /// null
     INT8 =   1,  /// int8
     INT16 =  2,  /// int16

--- a/source/dhtslib/vcf/package.d
+++ b/source/dhtslib/vcf/package.d
@@ -73,7 +73,7 @@ enum RecordType{
 
 /// Byte sizes for RecordType
 static immutable RecordTypeSizes = [0, 1, 2, 4, 8, 4, 1];
-alias RecordTypeToDType = AliasSeq!(null, byte, short, int, long, float, string);
+alias RecordTypeToDType = AliasSeq!(null, byte, short, int, long, float, null, string);
 
 /// Replacement for htslib VCF_*
 enum VariantType

--- a/source/dhtslib/vcf/package.d
+++ b/source/dhtslib/vcf/package.d
@@ -4,3 +4,97 @@ public import dhtslib.vcf.record;
 public import dhtslib.vcf.reader;
 public import dhtslib.vcf.header;
 public import dhtslib.vcf.writer;
+
+import std.meta : AliasSeq;
+
+/// Replacement for htslib BCF_HL_*
+enum HeaderRecordType
+{
+    NULL = -1,
+    FILTER =    0, /// header line: FILTER
+    INFO =      1, /// header line: INFO
+    FORMAT =    2, /// header line: FORMAT
+    CONTIG =    3, /// header line: contig
+    STRUCT =    4, /// header line: structured header line TAG=<A=..,B=..>
+    GENERIC =   5, /// header line: generic header line
+}
+
+/// Strings for HDR_LINE
+static immutable HeaderRecordTypeStrings = ["FILTER","INFO","FORMAT","contig", "struct", "generic"];
+
+/// Replacement for htslib BCF_HT_*
+enum HeaderTypes
+{
+    NULL = -1,
+    FLAG =  0, /// header type: FLAG// header type
+    INT =   1, /// header type: INTEGER
+    REAL =  2, /// header type: REAL,
+    FLOAT =  2, /// copy of REAL
+    STR =   3, /// header type: STRING
+    CHAR = 4,
+    LONG =  INT | 0x100, // BCF_HT_INT, but for int64_t values; VCF only!
+}
+
+/// Strings for HDR_TYPE
+static immutable HeaderTypesStrings = ["Flag","Integer","Float","String","Character","Long"];
+
+/// Replacement for htslib BCF_VL_*
+enum HeaderLengths
+{
+    NULL = -1,
+    FIXED = 0, /// variable length: fixed length
+    VAR =   1, /// variable length: variable
+    A =     2, /// variable length: one field per alt allele
+    G =     3, /// variable length: one field per genotype
+    R =     4, /// variable length: one field per allele including ref
+}
+
+/// Strings for HDR_LENGTH
+static immutable  HeaderLengthsStrings = ["FIXED",".","A","G","R"];
+
+/// Replacement for htslib BCF_DT_*
+enum HeaderDictTypes
+{
+    ID =     0, /// dictionary type: ID
+    CTG =    1, /// dictionary type: CONTIG
+    SAMPLE = 2, /// dictionary type: SAMPLE
+}
+
+/// Replacement for htslib BCF_BT_*
+enum RecordType{
+    NULL =   0,  /// null
+    INT8 =   1,  /// int8
+    INT16 =  2,  /// int16
+    INT32 =  3,  /// int32
+    INT64 =  4,  /// Unofficial, for internal use only per htslib headers 
+    FLOAT =  5,  /// float (32?)
+    CHAR =   7  /// char (8 bit)
+}
+
+/// Byte sizes for RecordType
+static immutable RecordTypeSizes = [0, 1, 2, 4, 8, 4, 1];
+alias RecordTypeToDType = AliasSeq!(null, byte, short, int, long, float, string);
+
+/// Replacement for htslib VCF_*
+enum VariantType
+{
+    REF =       0,  /// ref (e.g. in a gVCF)
+    SNP =       1,  /// SNP 
+    MNP =       2,  /// MNP
+    INDEL =     4,  /// INDEL
+    OTHER =     8,  /// other (e.g. SV)
+    BND =       16, /// breakend
+    OVERLAP =   32, /// overlapping deletion, ALT=* 
+}
+
+/// Replacement for htslib BCF_UN_*
+enum UNPACK
+{
+    ALT =   1, // up to ALT inclusive
+    FILT =   2, // up to FILTER
+    INFO =  4, // up to INFO
+    SHR =   ALT | FILT | INFO, // all shared information
+    FMT =   8, // unpack format and each sample
+    IND =   FMT, // a synonym of UNPACK.FMT
+    ALL =   SHR | FMT, // everything
+}

--- a/source/dhtslib/vcf/reader.d
+++ b/source/dhtslib/vcf/reader.d
@@ -4,8 +4,7 @@ import std.string: fromStringz, toStringz;
 import std.utf: toUTFz;
 import std.traits : ReturnType;
 
-import dhtslib.vcf.header;
-import dhtslib.vcf.record;
+import dhtslib.vcf;
 import dhtslib.tabix;
 import dhtslib.coordinates;
 import htslib.vcf;
@@ -14,12 +13,12 @@ import htslib.kstring;
 
 alias BCFReader = VCFReader;
 
-auto VCFReader(string fn, int MAX_UNPACK = BCF_UN_ALL)
+auto VCFReader(string fn, UNPACK MAX_UNPACK = UNPACK.ALL)
 {
     return VCFReaderImpl!(CoordSystem.zbc, false)(fn, MAX_UNPACK);
 }
 
-auto VCFReader(CoordSystem cs)(TabixIndexedFile tbxFile, string chrom, Interval!cs coords, int MAX_UNPACK = BCF_UN_ALL)
+auto VCFReader(CoordSystem cs)(TabixIndexedFile tbxFile, string chrom, Interval!cs coords, UNPACK MAX_UNPACK = UNPACK.ALL)
 {
     return VCFReaderImpl!(cs,true)(tbxFile, chrom, coords, MAX_UNPACK);
 }
@@ -32,7 +31,7 @@ struct VCFReaderImpl(CoordSystem cs, bool isTabixFile)
     //bcf_hdr_t   *hdr;   /// header
     VCFHeader   *vcfhdr;    /// header wrapper -- no copies
     bcf1_t* b;          /// record for use in iterator, will be recycled
-    int MAX_UNPACK;     /// see htslib.vcf
+    UNPACK MAX_UNPACK;     /// see htslib.vcf
 
     private static int refct;
 
@@ -50,7 +49,7 @@ struct VCFReaderImpl(CoordSystem cs, bool isTabixFile)
         ReturnType!(this.initializeTabixRange) tbxRange; /// For tabix use
 
         /// TabixIndexedFile and coordinates ctor
-        this(TabixIndexedFile tbxFile, string chrom, Interval!cs coords, int MAX_UNPACK = BCF_UN_ALL)
+        this(TabixIndexedFile tbxFile, string chrom, Interval!cs coords, UNPACK MAX_UNPACK = UNPACK.ALL)
         {
             this.tbx = tbxFile;
             this.tbxRange = initializeTabixRange(chrom, coords);
@@ -73,7 +72,7 @@ struct VCFReaderImpl(CoordSystem cs, bool isTabixFile)
     }else{
         /// read existing VCF file
         /// MAX_UNPACK: setting alternate value could speed reading
-        this(string fn, int MAX_UNPACK = BCF_UN_ALL)
+        this(string fn, UNPACK MAX_UNPACK = UNPACK.ALL)
         {
             import htslib.hts : hts_set_threads;
 

--- a/source/dhtslib/vcf/record.d
+++ b/source/dhtslib/vcf/record.d
@@ -702,7 +702,7 @@ unittest
     vw.addHeaderLineRaw("##INFO=<ID=NS,Number=1,Type=Integer,Description=\"Number of Samples With Data\">");
     vw.addHeaderLineKV("INFO", "<ID=DP,Number=1,Type=Integer,Description=\"Total Depth\">");
     // ##INFO=<ID=AF,Number=A,Type=Float,Description="Allele Frequency">
-    vw.addTag!"INFO"("AF", "A", "Integer", "Number of Samples With Data");
+    vw.vcfhdr.addHeaderLine!(HDR_LINE.INFO)("AF", HDR_LENGTH.A, HDR_TYPE.INT, "Number of Samples With Data");
     vw.addHeaderLineRaw("##contig=<ID=20,length=62435964,assembly=B36,md5=f126cdf8a6e0c7f379d618ff66beb2da,species=\"Homo sapiens\",taxonomy=x>"); // @suppress(dscanner.style.long_line)
     vw.addHeaderLineRaw("##FILTER=<ID=q10,Description=\"Quality below 10\">");
 

--- a/source/dhtslib/vcf/record.d
+++ b/source/dhtslib/vcf/record.d
@@ -1037,6 +1037,8 @@ unittest
     vw.addSample("NA12878");
     assert(vw.vcfhdr.nsamples == 1);
 
+    vw.writeHeader();
+
     auto r = new VCFRecord(vw.vcfhdr, bcf_init1());
     
     r.chrom = "20";
@@ -1208,6 +1210,8 @@ unittest
     assert(rr.toString == "20\t17330\t.\tT\tA\t3\t.\tNS=3;DP=11\tCH\ttest\n");
 
     assert(rr.coordinates == ZBHO(17329,17330));
+    vw.writeRecord(*r);
+    vw.writeRecord(vw.vcfhdr.hdr, r.line);
 
 
     // Finally, print the records:

--- a/source/dhtslib/vcf/record.d
+++ b/source/dhtslib/vcf/record.d
@@ -722,10 +722,9 @@ unittest
     hrec.setLength(HDR_LENGTH.A);
     hrec.setValueType(HDR_TYPE.FLOAT);
     hrec.setDescription("Allele Freq");
-    writeln(hrec);
     vw.vcfhdr.addHeaderRecord(hrec);
     
-    writeln(vw.vcfhdr.getHeaderRecord(HDR_LINE.FORMAT, "ID","AF"));
+    assert(vw.vcfhdr.getHeaderRecord(HDR_LINE.FORMAT, "ID","AF")["ID"] == "AF");
 
     // Exercise header
     assert(vw.vcfhdr.nsamples == 0);

--- a/source/dhtslib/vcf/writer.d
+++ b/source/dhtslib/vcf/writer.d
@@ -6,8 +6,7 @@ import std.traits: isArray, isDynamicArray, isBoolean, isIntegral, isFloatingPoi
 import std.conv: to, ConvException;
 import std.format: format;
 
-import dhtslib.vcf.header;
-import dhtslib.vcf.record;
+import dhtslib.vcf;
 import htslib.vcf;
 import htslib.hts_log;
 

--- a/source/dhtslib/vcf/writer.d
+++ b/source/dhtslib/vcf/writer.d
@@ -131,32 +131,32 @@ struct VCFWriter
     *   source:      Annotation source  (eg dbSNP)
     *   version:     Annotation version (eg 142)
     */
-    deprecated("use VCFHeader methods instead")
-    void addTag(string tagType, T)( string id,
-                                    T number,
-                                    string type,
-                                    string description,
-                                    string source="",
-                                    string _version="")
-    if((tagType == "INFO" || tagType == "FORMAT") && (isIntegral!T || isSomeString!T))
-    {
-        this.vcfhdr.addTag!(tagType, T)(id, number, type, description, source, _version);
-    }
+    // deprecated("use VCFHeader methods instead")
+    // void addTag(string tagType, T)( string id,
+    //                                 T number,
+    //                                 string type,
+    //                                 string description,
+    //                                 string source="",
+    //                                 string _version="")
+    // if((tagType == "INFO" || tagType == "FORMAT") && (isIntegral!T || isSomeString!T))
+    // {
+    //     this.vcfhdr.addTag!(tagType, T)(id, number, type, description, source, _version);
+    // }
 
     /** Add FILTER tag (§1.2.3) */
-    deprecated("use VCFHeader methods instead")
-    void addTag(string tagType)(string id, string description)
-    if(tagType == "FILTER")
-    {
-        this.vcfhdr.addTag!(tagType)(id, description);
-    }
+    // deprecated("use VCFHeader methods instead")
+    // void addTag(string tagType)(string id, string description)
+    // if(tagType == "FILTER")
+    // {
+    //     this.vcfhdr.addTag!(tagType)(id, description);
+    // }
 
     /** Add FILTER tag (§1.2.3) */
-    deprecated("use VCFHeader methods instead")
-    void addFilterTag(string id, string description)
-    {
-        this.vcfhdr.addFilterTag(id, description);
-    }
+    // deprecated("use VCFHeader methods instead")
+    // void addFilterTag(string id, string description)
+    // {
+    //     this.vcfhdr.addFilterTag(id, description);
+    // }
 
     /** Add contig definition (§1.2.7) to header meta-info 
     


### PR DESCRIPTION
Lots of changes went into this.

fixes #96.

### New Features:
- `HeaderRecord` wrapper struct for getting `VCFHeader` records in a structured format along with getters and setters and `VCFHeader` can now accept this type to add to a header.
- ability to remove header lines `removeHeaderLines`.
- Moved functions from `VCFReader` to `VCFHeader` as appropriate.
-  New `InfoField` and `FormatField` wrapper structs to get and transform VCF format and info data into D types (data is copied).
- New functions (`getInfos` and `getFormats`) to return a hashmap of all info and format data using new wrapper structs. 
- New function to remove info fields `removeInfo`.
- New enum replacements for htslib `BCF*` enums.
- lots of new unittests

Though I did introduce a lot of new features, I have tried to leave old functionality behind. (Though with the reorganization and the enums,  the API will change for most of `dhtslib.vcf`).

### Fixes:
- Fixes to `addFormat` and `addInfo` functions.
- Fixes for `VCFHeader` functions
- `VCFReader` now obeys Phobos Range rules, fixes #69
- Unittest coverage for all `dhtslib.vcf` modules is >= 92%, fixes #94

### Concerns:
1. We sometimes report errors through `hts_log` and have the function return, sometimes we report errors through `hts_log` and have the function throw an exception, or sometimes we just throw an exception. We should decide formally on how this should be done across the whole package, #99 probably relevant.
2. Naming in general. I am not sold on my naming of the new enums, I just wanted them to be more informative than the htslib enums.
3. Could use more asserts and checks 
