### PR TITLE
Htslib package changes

### DIFF
--- a/source/dhtslib/sam/record.d
+++ b/source/dhtslib/sam/record.d
@@ -181,7 +181,7 @@ struct SAMRecord
     /// is read reversed?
     /// bool bam_is_rev(bam1_t *b) { return ( ((*b).core.flag & BAM_FREVERSE) != 0 ); }
     pragma(inline, true)
-    @nogc @safe nothrow
+    @nogc @trusted nothrow
     @property bool isReversed()
     {
         return bam_is_rev(this.b);
@@ -190,7 +190,7 @@ struct SAMRecord
     /// is mate reversed?
     /// bool bam_is_mrev(bam1_t *b) { return( ((*b).core.flag & BAM_FMREVERSE) != 0); }
     pragma(inline, true)
-    @nogc @safe nothrow
+    @nogc @trusted nothrow
     @property bool mateReversed()
     {
         return bam_is_mrev(this.b);

--- a/source/dhtslib/sam/record.d
+++ b/source/dhtslib/sam/record.d
@@ -149,6 +149,7 @@ struct SAMRecord
 
     /// is read paired?
     pragma(inline, true)
+    @nogc @safe nothrow
     @property bool isPaired()
     {
         return cast(bool)(b.core.flag & BAM_FPAIRED);
@@ -254,6 +255,7 @@ struct SAMRecord
     /// if you keep this around you should copy it
     /// -- wraps bam_get_qname(bam1_t *b)
     pragma(inline, true)
+    @nogc @trusted nothrow
     @property const(char)[] queryName()
     {
         // auto bam_get_qname(bam1_t *b) { return (cast(char*)(*b).data); }
@@ -262,6 +264,7 @@ struct SAMRecord
     
     /// Set query name (read name)
     pragma(inline, true)
+    @trusted nothrow
     @property void queryName(string qname)
     {
         auto ret = bam_set_qname(this.b, toStringz(qname));
@@ -279,6 +282,8 @@ struct SAMRecord
 
     /// Return char array of the sequence
     /// see samtools/sam_view.c: get_read
+    pragma(inline, true)
+    @trusted nothrow
     @property const(char)[] sequence()
     {
         // calloc fills with \0; +1 len for Cstring
@@ -298,6 +303,7 @@ struct SAMRecord
 
     /// Assigns sequence and resets quality score
     pragma(inline, true)
+    @trusted nothrow
     @property void sequence(const(char)[] seq)
     {
         /// There is no bam_seq_seq
@@ -350,7 +356,7 @@ struct SAMRecord
     /// see samtools/sam_view.c: get_quality
     /// TODO: Discussion -- should we return const(ubyte[]) or const(ubyte)[] instead?
     pragma(inline, true)
-    @nogc
+    @nogc @trusted nothrow
     @property const(ubyte)[] qscores()
     {
         auto slice = bam_get_qual(this.b)[0 .. this.b.core.l_qseq];
@@ -359,6 +365,7 @@ struct SAMRecord
 
     /// Set quality scores from raw ubyte quality score array given that it is the same length as the bam sequence
     pragma(inline, true)
+    @trusted nothrow
     @property void qscores(const(ubyte)[] seq)
     {
         /// There is no bam_seq_qual
@@ -375,6 +382,7 @@ struct SAMRecord
 
     /// get phred-scaled base qualities as char array
     pragma(inline, true)
+    @trusted nothrow
     const(char)[] qscoresPhredScaled()
     {
         auto bqs = this.qscores.dup;
@@ -391,6 +399,7 @@ struct SAMRecord
 
     /// Assign a cigar string
     pragma(inline, true)
+    @trusted
     @property void cigar(Cigar cigar)
     {
         // no bam_set_cigar

--- a/source/htslib/bgzf.d
+++ b/source/htslib/bgzf.d
@@ -35,6 +35,10 @@ import core.sys.posix.sys.types;
 import htslib.hfile : hFILE;
 import htslib.kstring;
 
+@system:
+nothrow:
+@nogc:
+
 // ssize_t doesn't exist in core.sys.posix.sys.types for windows builds
 version(Windows){
     version(Win32){

--- a/source/htslib/cram.d
+++ b/source/htslib/cram.d
@@ -42,6 +42,10 @@ import htslib.sam;
 import htslib.hts;
 import htslib.hfile : hFILE;
 
+@system:
+nothrow:
+@nogc:
+
 extern (C):
 
 // see cram/cram_structs.h for an internal more complete copy of this enum

--- a/source/htslib/faidx.d
+++ b/source/htslib/faidx.d
@@ -30,6 +30,10 @@ module htslib.faidx;
 
 import htslib.hts : hts_pos_t;
 
+@system:
+nothrow:
+@nogc:
+
 extern (C):
 
 /** @file

--- a/source/htslib/hfile.d
+++ b/source/htslib/hfile.d
@@ -29,6 +29,10 @@ import core.stdc.string : memcpy, strlen;
 
 import htslib.kstring : kstring_t;
 
+@system:
+nothrow:
+@nogc:
+
 extern (C):
 
 //#include <sys/types.h>

--- a/source/htslib/hts.d
+++ b/source/htslib/hts.d
@@ -38,6 +38,10 @@ import htslib.thread_pool : hts_tpool;
 import htslib.sam : sam_hdr_t;
 import htslib.kstring : kstring_t;
 
+@system:
+nothrow:
+@nogc:
+
 extern (C):
 
 // Separator used to split HTS_PATH (for plugins); REF_PATH (cram references)

--- a/source/htslib/hts_endian.d
+++ b/source/htslib/hts_endian.d
@@ -26,6 +26,9 @@ module htslib.hts_endian;
 
 import core.stdc.config;
 
+@system:
+@nogc:
+
 /*
  * Compile-time endianness tests.
  *

--- a/source/htslib/hts_expr.d
+++ b/source/htslib/hts_expr.d
@@ -25,6 +25,10 @@ module htslib.hts_expr;
 
 import htslib.kstring: kstring_t;
 
+@system:
+nothrow:
+@nogc:
+
 extern (C):
 
 /// Holds a filter variable.  This is also used to return the results.

--- a/source/htslib/hts_log.d
+++ b/source/htslib/hts_log.d
@@ -29,6 +29,9 @@ module htslib.hts_log;
 
 import std.string: toStringz;
 
+@system:
+nothrow:
+
 extern (C):
 
 /// Log levels.

--- a/source/htslib/hts_os.d
+++ b/source/htslib/hts_os.d
@@ -26,6 +26,10 @@ module htslib.hts_os;
 
 import core.stdc.config;
 
+@system:
+nothrow:
+@nogc:
+
 extern (C):
 
 /* This is srand48_deterministic() on platforms that provide it, or srand48()

--- a/source/htslib/kbitset.d
+++ b/source/htslib/kbitset.d
@@ -29,6 +29,10 @@ import core.stdc.limits;
 import core.stdc.stdlib;
 import core.stdc.string;
 
+@system:
+nothrow:
+@nogc:
+
 extern (C):
 
 /* Example of using kbitset_t, which represents a subset of {0,..., N-1},

--- a/source/htslib/kfunc.d
+++ b/source/htslib/kfunc.d
@@ -25,6 +25,10 @@
 */
 module htslib.kfunc;
 
+@system:
+nothrow:
+@nogc:
+
 extern (C):
 
 /* Log gamma function

--- a/source/htslib/knetfile.d
+++ b/source/htslib/knetfile.d
@@ -28,6 +28,10 @@ module htslib.knetfile;
 import core.sys.posix.fcntl;
 import core.sys.posix.sys.types;
 
+@system:
+nothrow:
+@nogc:
+
 extern (C):
 
 // alias netread = read;

--- a/source/htslib/kroundup.d
+++ b/source/htslib/kroundup.d
@@ -24,6 +24,10 @@
 */
 module htslib.kroundup;
 
+@system:
+nothrow:
+@nogc:
+
 /// round 32 or 64 bit (u)int x to power of 2 that is equal or greater (JSB)
 pragma(inline, true)
 extern (D)

--- a/source/htslib/kstring.d
+++ b/source/htslib/kstring.d
@@ -25,6 +25,10 @@
 */
 module htslib.kstring;
 
+@system:
+nothrow:
+@nogc:
+
 import core.stdc.config : c_long;
 import core.stdc.stdarg;
 import core.stdc.stdio : EOF;

--- a/source/htslib/package.d
+++ b/source/htslib/package.d
@@ -1,0 +1,24 @@
+module htslib;
+
+public import htslib.bgzf;
+public import htslib.cram;
+public import htslib.faidx;
+public import htslib.hfile;
+public import htslib.hts_endian;
+public import htslib.hts_expr;
+public import htslib.hts_log;
+public import htslib.hts_os;
+public import htslib.hts;
+public import htslib.kbitset;
+public import htslib.kfunc;
+public import htslib.knetfile;
+public import htslib.kroundup;
+public import htslib.kstring;
+public import htslib.regidx;
+public import htslib.sam;
+public import htslib.synced_bcf_reader;
+public import htslib.tbx;
+public import htslib.thread_pool;
+public import htslib.vcf_sweep;
+public import htslib.vcf;
+public import htslib.vcfutils;

--- a/source/htslib/regidx.d
+++ b/source/htslib/regidx.d
@@ -64,6 +64,10 @@ module htslib.regidx;
 
 import htslib.hts: hts_pos_t;
 
+@system:
+nothrow:
+@nogc:
+
 extern (C):
 
 // maximum regidx position (0-based).  Used to represent the end point of

--- a/source/htslib/sam.d
+++ b/source/htslib/sam.d
@@ -35,7 +35,9 @@ import htslib.hts_log;
 import htslib.bgzf : BGZF;
 import htslib.kstring : kstring_t, ssize_t;
 
+@system:
 extern (C):
+@nogc nothrow {
 
 /// Highest SAM format version supported by this library
 enum SAM_FORMAT_VERSION = "1.6";
@@ -1447,6 +1449,8 @@ hts_itr_t* sam_itr_regarray(
     char** regarray,
     uint regcount);
 
+} /// closing @nogc
+
 /// Get the next read from a SAM/BAM/CRAM iterator
 /** @param htsfp       Htsfile pointer for the input file
     @param itr         Iterator
@@ -1469,6 +1473,8 @@ int sam_itr_next(htsFile* htsfp, hts_itr_t* itr, bam1_t* r) {
     else
         return hts_itr_next(htsfp.is_bgzf ? htsfp.fp.bgzf : null, itr, r, htsfp);
 }
+
+@nogc nothrow:
 
 /// Get the next read from a BAM/CRAM multi-iterator
 /** @param htsfp       Htsfile pointer for the input file

--- a/source/htslib/synced_bcf_reader.d
+++ b/source/htslib/synced_bcf_reader.d
@@ -61,6 +61,10 @@ import htslib.vcf;
 import htslib.kstring : kstring_t;
 import htslib.tbx : tbx_t;
 
+@system:
+nothrow:
+@nogc:
+
 extern (C):
 
 /*

--- a/source/htslib/tbx.d
+++ b/source/htslib/tbx.d
@@ -28,6 +28,10 @@ module htslib.tbx;
 import htslib.hts;
 import htslib.bgzf : BGZF;
 
+@system:
+nothrow:
+@nogc:
+
 extern (C):
 
 enum TBX_MAX_SHIFT = 31;

--- a/source/htslib/thread_pool.d
+++ b/source/htslib/thread_pool.d
@@ -45,6 +45,10 @@ DEALINGS IN THE SOFTWARE.  */
  */
 module htslib.thread_pool;
 
+@system:
+nothrow:
+@nogc:
+
 extern (C):
 
 /*-----------------------------------------------------------------------------

--- a/source/htslib/vcf.d
+++ b/source/htslib/vcf.d
@@ -43,9 +43,9 @@ import htslib.hts_endian;
 import htslib.kstring : kstring_t;
 import htslib.bgzf : BGZF;
 
-
-
+@system:
 extern (C):
+@nogc nothrow {
 
 /* Included only for backwards compatibility with e.g. bcftools 1.10 */
 
@@ -923,6 +923,9 @@ auto bcf_update_info_int64( const(bcf_hdr_t) *hdr, bcf1_t *line,
  *
  *  Returns 0 on success or negative value on error.
  */
+
+}/// closing @nogc nothrow
+
 pragma(inline, true) {
     auto bcf_update_format_int32(const(bcf_hdr_t) *hdr, bcf1_t *line, const(char) *key, const(int) *values, int n) // @suppress(dscanner.style.undocumented_declaration)
         { return bcf_update_format(hdr, line, key, values, n, BCF_HT_INT); }
@@ -934,6 +937,8 @@ pragma(inline, true) {
         { return bcf_update_format(hdr, line, toStringz("GT"c), gts, n, BCF_HT_INT); 
     }
 }
+
+@nogc nothrow {
 
 int bcf_update_format_string (
     const(bcf_hdr_t)* hdr,
@@ -1126,6 +1131,9 @@ auto bcf_get_info_int64(const(bcf_hdr_t) *hdr, bcf1_t *line,
  *      free(gt_arr);
  *
  */
+
+}/// closing @nogc nothrow from line 928
+
 pragma(inline, true) {
     auto bcf_get_format_int32(const(bcf_hdr_t) *hdr, bcf1_t *line, const(char) *tag, void **dst, int *ndst) // @suppress(dscanner.style.undocumented_declaration) // @suppress(dscanner.style.long_line)
         { return bcf_get_format_values(hdr, line, tag, cast(void**) dst, ndst, BCF_HT_INT); }
@@ -1136,6 +1144,8 @@ pragma(inline, true) {
     auto bcf_get_genotypes(const(bcf_hdr_t) *hdr, bcf1_t *line, void **dst, int *ndst) // @suppress(dscanner.style.undocumented_declaration) // @suppress(dscanner.style.long_line)
         { return bcf_get_format_values(hdr, line, toStringz("GT"c), cast(void**) dst, ndst, BCF_HT_INT); }
 }
+
+@nogc nothrow {
 
 int bcf_get_format_string(
     const(bcf_hdr_t)* hdr,
@@ -1272,6 +1282,8 @@ int bcf_enc_vfloat(kstring_t* s, int n, float* a);
 
 alias bcf_itr_destroy = hts_itr_destroy;
 
+} /// closing @nogc nothrow from line 1136
+
 pragma(inline, true) {
     /// Generate an iterator for an integer-based range query
     auto bcf_itr_queryi(const(hts_idx_t) *idx, int tid, int beg, int end)
@@ -1293,6 +1305,9 @@ pragma(inline, true) {
         errno = EINVAL;
         return -2;
     }
+
+@nogc nothrow:
+
 /// Load a BCF index
 /** @param fn   BCF file name
     @return The index, or NULL if an error occurred.

--- a/source/htslib/vcf_sweep.d
+++ b/source/htslib/vcf_sweep.d
@@ -26,6 +26,10 @@ module htslib.vcf_sweep;
 
 import htslib.vcf;
 
+@system:
+nothrow:
+@nogc:
+
 extern (C):
 
 struct bcf_sweep_t;

--- a/source/htslib/vcfutils.d
+++ b/source/htslib/vcfutils.d
@@ -26,6 +26,10 @@ module htslib.vcfutils;
 
 import htslib.vcf;
 
+@system:
+nothrow:
+@nogc:
+
 extern (C):
 
 struct kbitset_t;


### PR DESCRIPTION
Can now `import htslib;` and get all htslib functions.

Most htslib bindings have had the attributes `@nogc @trusted nothrow` added.

Changes to `SAMRecord` to add attributes to most functions. I am considering doing this for the rest of our functions across `dhtslib`. This would allow us to be explicit about which functions use gc and which are safe.