### PR TITLE
Vcf improvements and fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,12 +21,17 @@ bug_minimal
 sam_iter
 csam_iter
 dhtslib-test-unittest
+coordinates/coordinates-test-unittest
+dhtslib-test-unittest-safety
+chunkby
+cigartest
 
 # DUB
 .dub
 docs.json
 __dummy.html
 docs/
+dub.selections.json
 
 # Code coverage
 *.lst

--- a/source/dhtslib/bed/reader.d
+++ b/source/dhtslib/bed/reader.d
@@ -12,8 +12,8 @@ auto BedReader(string fn)
 }
 
 /// ditto
-auto BedReader(CoordSystem cs)(string fn, string chrom, Interval!cs coords, string fnIdx = "")
+auto BedReader(CoordSystem cs)(string fn, string chrom, Interval!cs coords, int extra_threads = -1, string fnIdx = "")
 {
-    return RecordReaderRegion!(BedRecord, cs)(fn, chrom, coords, fnIdx);
+    return RecordReaderRegion!(BedRecord, cs)(fn, chrom, coords, extra_threads, fnIdx);
 }
 

--- a/source/dhtslib/gff/reader.d
+++ b/source/dhtslib/gff/reader.d
@@ -14,9 +14,9 @@ auto GFF3Reader(string fn)
 }
 
 /// ditto
-auto GFF3Reader(CoordSystem cs)(string fn, string chrom, Interval!cs coords, string fnIdx = "")
+auto GFF3Reader(CoordSystem cs)(string fn, string chrom, Interval!cs coords, int extra_threads = -1, string fnIdx = "")
 {
-    return RecordReaderRegion!(GFF3Record, cs)(fn, chrom, coords, fnIdx);
+    return RecordReaderRegion!(GFF3Record, cs)(fn, chrom, coords, extra_threads, fnIdx);
 }
 
 /// Returns a RecordReader range for a GTF file
@@ -26,9 +26,9 @@ auto GTFReader(string fn)
 }
 
 /// ditto
-auto GTFReader(CoordSystem cs)(string fn, string chrom, Interval!cs coords, string fnIdx = "")
+auto GTFReader(CoordSystem cs)(string fn, string chrom, Interval!cs coords, int extra_threads = -1, string fnIdx = "")
 {
-    return RecordReaderRegion!(GTFRecord, cs)(fn, chrom, coords, fnIdx);
+    return RecordReaderRegion!(GTFRecord, cs)(fn, chrom, coords, extra_threads, fnIdx);
 }
 
 /// Returns a RecordReader range for a GFF2 file

--- a/source/dhtslib/tabix.d
+++ b/source/dhtslib/tabix.d
@@ -57,6 +57,15 @@ struct TabixIndexedFile {
                 // but overcomitting by 1 thread (i.e., passing totalCPUs) buys an extra 3% on my 2-core 2013 Mac
                 hts_set_threads(this.fp, totalCPUs);
             }
+        } else if (extra_threads > 0)
+        {
+            if ((extra_threads + 1) > totalCPUs)
+                hts_log_warning(__FUNCTION__, "More threads requested than CPU cores detected");
+            hts_set_threads(this.fp, extra_threads);
+        }
+        else if (extra_threads == 0)
+        {
+            hts_log_debug(__FUNCTION__, "Zero extra threads requested");
         }
 
         //enum htsExactFormat format = hts_get_format(fp)->format;

--- a/source/dhtslib/tabix.d
+++ b/source/dhtslib/tabix.d
@@ -12,9 +12,11 @@ import std.stdio;
 import std.string;
 import std.traits : ReturnType;
 import std.range : inputRangeObject, InputRangeObject;
+import std.parallelism : totalCPUs;
 import core.stdc.stdlib : malloc, free;
 
 import htslib.hts;
+import htslib.hts_log;
 import htslib.kstring;
 import htslib.tbx;
 import dhtslib.coordinates;
@@ -36,7 +38,7 @@ struct TabixIndexedFile {
 
     /// Initialize with a complete file path name to the tabix-indexed file
     /// The tabix index (.tbi) must already exist alongside
-    this(const(char)[] fn, const(char)[] fntbi = "")
+    this(const(char)[] fn, int extra_threads = -1, const(char)[] fntbi = "")
     {
         debug(dhtslib_debug) { writeln("TabixIndexedFile ctor"); }
         this.fp = HtsFile(hts_open( toStringz(fn), "r"));
@@ -44,6 +46,19 @@ struct TabixIndexedFile {
             writefln("Could not read %s\n", fn);
             throw new Exception("Couldn't read file");
         }
+
+        if (extra_threads == -1)
+        {
+            if ( totalCPUs > 1)
+            {
+                hts_log_info(__FUNCTION__,
+                        format("%d CPU cores detected; enabling multithreading", totalCPUs));
+                // hts_set_threads adds N _EXTRA_ threads, so totalCPUs - 1 seemed reasonable,
+                // but overcomitting by 1 thread (i.e., passing totalCPUs) buys an extra 3% on my 2-core 2013 Mac
+                hts_set_threads(this.fp, totalCPUs);
+            }
+        }
+
         //enum htsExactFormat format = hts_get_format(fp)->format;
         if(fntbi!="") this.tbx = Tbx(tbx_index_load2( toStringz(fn), toStringz(fntbi) ));
         else this.tbx = Tbx(tbx_index_load( toStringz(fn) ));
@@ -209,9 +224,9 @@ struct RecordReaderRegion(RecType, CoordSystem cs)
     bool emptyLine = false;
     
     /// string chrom and Interval ctor
-    this(string fn, string chrom, Interval!cs coords, string fnIdx = "")
+    this(string fn, string chrom, Interval!cs coords, int extra_threads = -1, string fnIdx = "")
     {
-        this.file = TabixIndexedFile(fn, fnIdx);
+        this.file = TabixIndexedFile(fn, extra_threads, fnIdx);
         this.chrom = chrom;
         this.coords = coords;
         this.header = this.file.header;

--- a/source/dhtslib/vcf/header.d
+++ b/source/dhtslib/vcf/header.d
@@ -314,10 +314,17 @@ struct VCFHeader
     pragma(inline, true)
     @property int nsamples() { return bcf_hdr_nsamples(this.hdr); }
 
+    /// get int index of sample name
     int getSampleId(string sam){
         auto ret = bcf_hdr_id2int(this.hdr, HeaderDictTypes.Sample, toUTFz!(char *)(sam));
         if(ret == -1) hts_log_error(__FUNCTION__, "Couldn't find sample in header: " ~ sam);
         return ret;
+    }
+
+    /// get sample list
+    string[] getSamples(){
+        auto samples = this.hdr.samples[0..this.nsamples];
+        return samples.map!(x => fromStringz(x).idup).array;
     }
 
     // TODO

--- a/source/dhtslib/vcf/reader.d
+++ b/source/dhtslib/vcf/reader.d
@@ -92,6 +92,15 @@ struct VCFReaderImpl(CoordSystem cs, bool isTabixFile)
                     // but overcomitting by 1 thread (i.e., passing totalCPUs) buys an extra 3% on my 2-core 2013 Mac
                     hts_set_threads(this.fp, totalCPUs);
                 }
+            } else if (extra_threads > 0)
+            {
+                if ((extra_threads + 1) > totalCPUs)
+                    hts_log_warning(__FUNCTION__, "More threads requested than CPU cores detected");
+                hts_set_threads(this.fp, extra_threads);
+            }
+            else if (extra_threads == 0)
+            {
+                hts_log_debug(__FUNCTION__, "Zero extra threads requested");
             }
 
             this.vcfhdr = VCFHeader(bcf_hdr_read(this.fp));

--- a/source/dhtslib/vcf/reader.d
+++ b/source/dhtslib/vcf/reader.d
@@ -3,6 +3,8 @@ module dhtslib.vcf.reader;
 import std.string: fromStringz, toStringz;
 import std.utf: toUTFz;
 import std.traits : ReturnType;
+import std.parallelism : totalCPUs;
+import std.format : format;
 
 import dhtslib.vcf;
 import dhtslib.tabix;
@@ -15,14 +17,16 @@ import htslib.kstring;
 
 alias BCFReader = VCFReader;
 
-auto VCFReader(string fn, UnpackLevel MAX_UNPACK = UnpackLevel.None)
+/** Basic support for reading VCF, BCF files */
+auto VCFReader(string fn, int extra_threads = -1, UnpackLevel MAX_UNPACK = UnpackLevel.None)
 {
-    return VCFReaderImpl!(CoordSystem.zbc, false)(fn, MAX_UNPACK);
+    return VCFReaderImpl!(CoordSystem.zbc, false)(fn, extra_threads, MAX_UNPACK);
 }
 
-auto VCFReader(CoordSystem cs)(TabixIndexedFile tbxFile, string chrom, Interval!cs coords, UnpackLevel MAX_UNPACK = UnpackLevel.None)
+/** Basic support for reading VCF, BCF files via tabix*/
+auto VCFReader(CoordSystem cs)(TabixIndexedFile tbxFile, string chrom, Interval!cs coords, int extra_threads = -1, UnpackLevel MAX_UNPACK = UnpackLevel.None)
 {
-    return VCFReaderImpl!(cs,true)(tbxFile, chrom, coords, MAX_UNPACK);
+    return VCFReaderImpl!(cs,true)(tbxFile, chrom, coords, extra_threads, MAX_UNPACK);
 }
 
 /** Basic support for reading VCF, BCF files */
@@ -45,7 +49,7 @@ struct VCFReaderImpl(CoordSystem cs, bool isTabixFile)
         ReturnType!(this.initializeTabixRange) tbxRange; /// For tabix use
 
         /// TabixIndexedFile and coordinates ctor
-        this(TabixIndexedFile tbxFile, string chrom, Interval!cs coords, UnpackLevel MAX_UNPACK = UnpackLevel.None)
+        this(TabixIndexedFile tbxFile, string chrom, Interval!cs coords, int extra_threads = -1, UnpackLevel MAX_UNPACK = UnpackLevel.None)
         {
             this.tbx = tbxFile;
             this.tbxRange = initializeTabixRange(chrom, coords);
@@ -69,7 +73,7 @@ struct VCFReaderImpl(CoordSystem cs, bool isTabixFile)
     }else{
         /// read existing VCF file
         /// MAX_UNPACK: setting alternate value could speed reading
-        this(string fn, UnpackLevel MAX_UNPACK = UnpackLevel.None)
+        this(string fn, int extra_threads = -1, UnpackLevel MAX_UNPACK = UnpackLevel.None)
         {
             import htslib.hts : hts_set_threads;
 
@@ -77,8 +81,18 @@ struct VCFReaderImpl(CoordSystem cs, bool isTabixFile)
             if (fn == "") throw new Exception("Empty filename passed to VCFReader constructor");
             this.fp = VcfFile(vcf_open(toStringz(fn), "r"c.ptr));
             if (!this.fp) throw new Exception("Could not hts_open file");
-            
-            hts_set_threads(this.fp, 1);    // extra decoding thread
+
+            if (extra_threads == -1)
+            {
+                if ( totalCPUs > 1)
+                {
+                    hts_log_info(__FUNCTION__,
+                            format("%d CPU cores detected; enabling multithreading", totalCPUs));
+                    // hts_set_threads adds N _EXTRA_ threads, so totalCPUs - 1 seemed reasonable,
+                    // but overcomitting by 1 thread (i.e., passing totalCPUs) buys an extra 3% on my 2-core 2013 Mac
+                    hts_set_threads(this.fp, totalCPUs);
+                }
+            }
 
             this.vcfhdr = VCFHeader(bcf_hdr_read(this.fp));
 

--- a/source/dhtslib/vcf/reader.d
+++ b/source/dhtslib/vcf/reader.d
@@ -260,6 +260,7 @@ debug(dhtslib_unittest) unittest
     assert(rec.allelesAsArray == ["C","T"]);
     assert(approxEqual(rec.qual, 59.2));
     assert(rec.filter == "PASS");
+    assert(vcf.vcfhdr.getSamples == ["A", "B"]);
 
     vcf.popFront;
     rec = vcf.front;

--- a/source/dhtslib/vcf/record.d
+++ b/source/dhtslib/vcf/record.d
@@ -302,8 +302,10 @@ struct FormatField
             }
             ret = (cast(T *)this.data.ptr)[0 .. this.n * this.nSamples * T.sizeof];
         }
-        return ret.chunks(this.n);
-
+        static if(isSomeString!T)
+            return ret.chunks(1);
+        else 
+            return ret.chunks(this.n);
     }
 }
 

--- a/source/dhtslib/vcf/record.d
+++ b/source/dhtslib/vcf/record.d
@@ -1190,7 +1190,7 @@ unittest
     hts_set_log_level(htsLogLevel.HTS_LOG_TRACE);
 
 
-    auto vw = VCFWriter("/dev/null");
+    auto vw = VCFWriter("/dev/null", VCFWriterTypes.VCF);
 
     vw.addHeaderLineRaw("##INFO=<ID=NS,Number=1,Type=Integer,Description=\"Number of Samples With Data\">");
     vw.addHeaderLineKV("INFO", "<ID=DP,Number=1,Type=Integer,Description=\"Total Depth\">");

--- a/source/dhtslib/vcf/record.d
+++ b/source/dhtslib/vcf/record.d
@@ -292,7 +292,11 @@ struct FormatField
             auto ptr = this.data.ptr;
             for(auto i=0; i < nSamples; i++)
             {
-                ret ~= fromStringz((cast(char *)ptr)[i*size .. (i+1) * size]).idup;
+                auto chrArr = (cast(char *)ptr)[i*size .. (i+1) * size];
+                if(chrArr[$-1])
+                    ret ~= chrArr.idup;
+                else
+                    ret ~= fromStringz(chrArr.ptr).idup;
             }
         }else{
             if(!(this.type == cast(BcfRecordType) staticIndexOf!(T, RecordTypeToDType)))

--- a/source/dhtslib/vcf/record.d
+++ b/source/dhtslib/vcf/record.d
@@ -292,7 +292,7 @@ struct FormatField
             auto ptr = this.data.ptr;
             for(auto i=0; i < nSamples; i++)
             {
-                ret ~= (cast(char *)ptr)[i*size .. (i+1) * size].idup;
+                ret ~= fromStringz((cast(char *)ptr)[i*size .. (i+1) * size]).idup;
             }
         }else{
             if(!(this.type == cast(BcfRecordType) staticIndexOf!(T, RecordTypeToDType)))

--- a/source/dhtslib/vcf/record.d
+++ b/source/dhtslib/vcf/record.d
@@ -304,7 +304,7 @@ struct FormatField
                 hts_log_error(__FUNCTION__, "Cannot convert %s to %s".format(type, T.stringof));
                 return ret.chunks(this.n);
             }
-            ret = (cast(T *)this.data.ptr)[0 .. this.n * this.nSamples * T.sizeof];
+            ret = (cast(T *)this.data.ptr)[0 .. this.n * this.nSamples];
         }
         static if(isSomeString!T)
             return ret.chunks(1);

--- a/source/dhtslib/vcf/record.d
+++ b/source/dhtslib/vcf/record.d
@@ -414,9 +414,8 @@ struct Genotype
     auto toString(T)() const {
         string ret;
         foreach(i, gt; cast(GT!T[]) this.data) {
-            if(i) {
-                ret ~= ['/','|'][gt.isMissing];
-            }
+            if(i)
+                ret ~= ['/','|'][gt.phased];
             if(gt.isPadding) {
                 ret = ret[0..$-1];
                 break;

--- a/source/dhtslib/vcf/record.d
+++ b/source/dhtslib/vcf/record.d
@@ -393,6 +393,23 @@ struct Genotype
                 assert(0);
         }
     }
+    
+    bool isNull()
+    {
+        final switch(this.type){
+            case BcfRecordType.Int8:
+                return (cast(GT!byte[])(this.data)).filter!(x=>!x.isMissing).empty;
+            case BcfRecordType.Int16:
+                return (cast(GT!short[])(this.data)).filter!(x=>!x.isMissing).empty;
+            case BcfRecordType.Int32:
+                return (cast(GT!int[])(this.data)).filter!(x=>!x.isMissing).empty;
+            case BcfRecordType.Int64:
+            case BcfRecordType.Float:
+            case BcfRecordType.Char:
+            case BcfRecordType.Null:
+                assert(0);
+        }
+    }
 
     /// get genotype ploidy
     auto getPloidy() {

--- a/source/dhtslib/vcf/writer.d
+++ b/source/dhtslib/vcf/writer.d
@@ -10,16 +10,37 @@ import dhtslib.memory;
 import dhtslib.vcf;
 import htslib.vcf;
 import htslib.hts_log;
+import htslib.hfile;
 
 alias BCFWriter = VCFWriter;
+
+/// VCF/BCF/Compressed VCF/ Uncompressed BCF on-disk format.
+/// `DEDUCE` will attempt to auto-detect from filename or other means
+enum VCFWriterTypes
+{
+    VCF, /// Regular VCF
+    BCF, /// Compressed BCF
+    UBCF, /// Uncompressed BCF
+    CVCF, /// Compressed VCF (vcf.gz)
+    DEDUCE /// Determine based on file extension
+}
 
 /** Basic support for writing VCF, BCF files */
 struct VCFWriter
 {
+    /// filename; as usable from D
+    string filename;
+
+    /// filename \0-terminated C string; reference needed to avoid GC reaping result of toStringz when ctor goes out of scope
+    private const(char)* fn;
+
     // htslib data structures
     VcfFile     fp;    /// rc htsFile wrapper
     VCFHeader   vcfhdr;    /// header wrapper
     Bcf1[]    rows;   /// individual records
+
+    /// hFILE if required
+    private hFILE* f;
 
     @disable this();
     /// open file or network resources for writing
@@ -27,43 +48,68 @@ struct VCFWriter
     /// if mode==w:
     ///     bcf_hdr_init automatically sets version string (##fileformat=VCFv4.2)
     ///     bcf_hdr_init automatically adds the PASS filter
-    this(string fn)
+    this(T)(T f, VCFWriterTypes t=VCFWriterTypes.DEDUCE)
+    if (is(T == string) || is(T == File))
     {
-        if (fn == "") throw new Exception("Empty filename passed to VCFWriter constructor");
-        this.fp = VcfFile(vcf_open(toStringz(fn), toStringz("w"c)));
-        if (!this.fp) throw new Exception("Could not hts_open file");
-
-        this.vcfhdr = VCFHeader( bcf_hdr_init("w\0"c.ptr));
-        addFiledate();
-        bcf_hdr_sync(this.vcfhdr.hdr);
-
-        /+
-        hts_log_trace(__FUNCTION__, "Displaying header at construction");
-        //     int bcf_hdr_format(const(bcf_hdr_t) *hdr, int is_bcf, kstring_t *str);
-        kstring_t ks;
-        bcf_hdr_format(this.vcfhdr.hdr, 0, &ks);
-        char[] hdr;
-        hdr.length = ks.l;
-        import core.stdc.string: memcpy;
-        memcpy(hdr.ptr, ks.s, ks.l);
-        import std.stdio: writeln;
-        writeln(hdr);
-        +/
+        auto hdr = VCFHeader( bcf_hdr_init("w\0"c.ptr));
+        hdr.addFiledate();
+        bcf_hdr_sync(hdr.hdr);
+        this(f, hdr, t);
     }
     /// setup and copy a header from another BCF/VCF as template
-    this(T)(string fn, T other)
-    if(is(T == VCFHeader) || is(T == bcf_hdr_t*))
+    this(T, H)(T f, H header, VCFWriterTypes t=VCFWriterTypes.DEDUCE)
+    if((is(H == VCFHeader) || is(H == bcf_hdr_t*)) && (is(T == string) || is(T == File)))
     {
-        if (fn == "") throw new Exception("Empty filename passed to VCFWriter constructor");
-        this.fp = vcf_open(toStringz(fn), toStringz("w"c));
-        if (!this.fp) throw new Exception("Could not hts_open file");
 
-        static if(is(T == VCFHeader*)) { this.vcfhdr      = VCFHeader( bcf_hdr_dup(other.hdr) ); }
-        else static if(is(T == bcf_hdr_t*)) { this.vcfhdr = VCFHeader( bcf_hdr_dup(other) ); }
-    }
+        char[] mode;
+        if(t == VCFWriterTypes.BCF) mode=['w','b','\0'];
+        else if(t == VCFWriterTypes.UBCF) mode=['w','b','0','\0'];
+        else if(t == VCFWriterTypes.VCF) mode=['w','\0'];
+        else if(t == VCFWriterTypes.CVCF) mode=['w','z','\0'];
+        // open file
+        static if (is(T == string))
+        {
+            if(t == VCFWriterTypes.DEDUCE){
+                import std.path:extension, stripExtension;
+                auto ext=extension(f);
+                if(ext==".bcf") mode=['w','b','\0'];
+                else if(ext==".vcf") mode=['w','\0'];
+                else if(ext==".cram") mode=['w','c','\0'];
+                else if(ext==".gz") {
+                    auto extRemoved = stripExtension(f);
+                    if (extension(extRemoved) == ".vcf") mode=['w','z','\0'];
+                    else {
+                        hts_log_error(__FUNCTION__,"extension "~extension(extRemoved)~ext~" not valid");
+                        throw new Exception("DEDUCE VCFWriterType used with non-valid extension");
+                    }
+                }
+                else {
+                    hts_log_error(__FUNCTION__,"extension "~ext~" not valid");
+                    throw new Exception("DEDUCE VCFWriterType used with non-valid extension");
+                }
+            }
+            this.filename = f;
+            this.fn = toStringz(f);
 
-    invariant
-    {
+            if (f == "") throw new Exception("Empty filename passed to VCFWriter constructor");
+            this.fp = vcf_open(toStringz(f), mode.ptr);
+            if (!this.fp) throw new Exception("Could not hts_open file");
+        }
+        else static if (is(T == File))
+        {
+            assert(t!=VCFWriterTypes.DEDUCE);
+            this.filename = f.name();
+            this.fn = toStringz(f.name);
+            this.f = hdopen(f.fileno, cast(immutable(char)*) "w");
+            this.fp = hts_hopen(this.f, this.fn, mode.ptr);
+        }
+        else assert(0);
+
+        static if(is(H == VCFHeader*)) { this.vcfhdr      = VCFHeader( bcf_hdr_dup(header.hdr) ); }
+        else static if(is(H == VCFHeader)) { this.vcfhdr      = VCFHeader( bcf_hdr_dup(header.hdr)); }
+        else static if(is(H == bcf_hdr_t*)) { this.vcfhdr = VCFHeader( bcf_hdr_dup(header) ); }
+        else assert(0);
+
         assert(this.vcfhdr.hdr != null);
     }
 
@@ -266,7 +312,7 @@ unittest
     hts_set_log_level(htsLogLevel.HTS_LOG_TRACE);
 
 
-    auto vw = VCFWriter("/dev/null");
+    auto vw = VCFWriter("/dev/null", VCFWriterTypes.VCF);
 
     vw.addHeaderLineRaw("##INFO=<ID=NS,Number=1,Type=Integer,Description=\"Number of Samples With Data\">");
     vw.addHeaderLineKV("INFO", "<ID=DP,Number=1,Type=Integer,Description=\"Total Depth\">");
@@ -277,4 +323,174 @@ unittest
 
     assert(vw.getHeader.getHeaderRecord(HeaderRecordType.Filter, "filt2").getDescription == "\"test2\"");
     vw.writeHeader();
+}
+
+debug(dhtslib_unittest) unittest
+{
+    import std.stdio;
+    import htslib.hts_log;
+    import std.algorithm : map, count;
+    import std.array : array;
+    import std.path : buildPath, dirName;
+    import std.math : approxEqual;
+    hts_set_log_level(htsLogLevel.HTS_LOG_INFO);
+    hts_log_info(__FUNCTION__, "Testing VCFWriterTypes DEDUCE");
+    hts_log_info(__FUNCTION__, "Loading test file");
+    {
+        auto vcf = VCFReader(buildPath(dirName(dirName(dirName(dirName(__FILE__)))),"htslib","test","tabix","vcf_file.vcf"));
+        auto vcfw = VCFWriter("/tmp/test_vcf.vcf", vcf.vcfhdr);
+        
+        vcfw.writeHeader;
+        foreach(rec;vcf) {
+            vcfw.writeRecord(rec);
+        }
+        destroy(vcfw);
+    }
+    {
+        auto vcf = VCFReader("/tmp/test_vcf.vcf");
+        assert(vcf.count == 14);
+        vcf = VCFReader("/tmp/test_vcf.vcf");
+
+        VCFRecord rec = vcf.front;
+        assert(rec.chrom == "1");
+        assert(rec.pos == 3000149);
+        assert(rec.refAllele == "C");
+        assert(rec.altAllelesAsArray == ["T"]);
+        assert(rec.allelesAsArray == ["C","T"]);
+        assert(approxEqual(rec.qual,59.2));
+        assert(rec.filter == "PASS");
+    }
+    {
+        auto vcf = VCFReader(buildPath(dirName(dirName(dirName(dirName(__FILE__)))),"htslib","test","tabix","vcf_file.vcf"));
+        auto vcfw = VCFWriter("/tmp/test_vcf.bcf", vcf.vcfhdr);
+        
+        vcfw.writeHeader;
+        foreach(rec;vcf) {
+            vcfw.writeRecord(rec);
+        }
+        destroy(vcfw);
+    }
+    {
+        auto vcf = VCFReader("/tmp/test_vcf.bcf");
+        assert(vcf.count == 14);
+        vcf = VCFReader("/tmp/test_vcf.bcf");
+        
+        VCFRecord rec = vcf.front;
+        assert(rec.chrom == "1");
+        assert(rec.pos == 3000149);
+        assert(rec.refAllele == "C");
+        assert(rec.altAllelesAsArray == ["T"]);
+        assert(rec.allelesAsArray == ["C","T"]);
+        assert(approxEqual(rec.qual,59.2));
+        assert(rec.filter == "PASS");
+    }
+    {
+        auto vcf = VCFReader(buildPath(dirName(dirName(dirName(dirName(__FILE__)))),"htslib","test","tabix","vcf_file.vcf"));
+        auto vcfw = VCFWriter("/tmp/test_vcf.vcf.gz", vcf.vcfhdr);
+        
+        vcfw.writeHeader;
+        foreach(rec;vcf) {
+            vcfw.writeRecord(rec);
+        }
+        destroy(vcfw);
+    }
+    {
+        auto vcf = VCFReader("/tmp/test_vcf.vcf.gz");
+        assert(vcf.count == 14);
+        vcf = VCFReader("/tmp/test_vcf.vcf.gz");
+        
+        VCFRecord rec = vcf.front;
+        assert(rec.chrom == "1");
+        assert(rec.pos == 3000149);
+        assert(rec.refAllele == "C");
+        assert(rec.altAllelesAsArray == ["T"]);
+        assert(rec.allelesAsArray == ["C","T"]);
+        assert(approxEqual(rec.qual,59.2));
+        assert(rec.filter == "PASS");
+    }
+}
+
+debug(dhtslib_unittest) unittest
+{
+    import std.stdio;
+    import htslib.hts_log;
+    import std.algorithm : map, count;
+    import std.array : array;
+    import std.path : buildPath, dirName;
+    import std.math : approxEqual;
+    hts_set_log_level(htsLogLevel.HTS_LOG_INFO);
+    hts_log_info(__FUNCTION__, "Testing VCFWriterTypes");
+    hts_log_info(__FUNCTION__, "Loading test file");
+    {
+        auto vcf = VCFReader(buildPath(dirName(dirName(dirName(dirName(__FILE__)))),"htslib","test","tabix","vcf_file.vcf"));
+        auto vcfw = VCFWriter("/tmp/test_vcf.vcf", vcf.vcfhdr, VCFWriterTypes.CVCF);
+        
+        vcfw.writeHeader;
+        foreach(rec;vcf) {
+            vcfw.writeRecord(rec);
+        }
+        destroy(vcfw);
+    }
+    {
+        auto vcf = VCFReader("/tmp/test_vcf.vcf");
+        assert(vcf.count == 14);
+        vcf = VCFReader("/tmp/test_vcf.vcf");
+
+        VCFRecord rec = vcf.front;
+        assert(rec.chrom == "1");
+        assert(rec.pos == 3000149);
+        assert(rec.refAllele == "C");
+        assert(rec.altAllelesAsArray == ["T"]);
+        assert(rec.allelesAsArray == ["C","T"]);
+        assert(approxEqual(rec.qual,59.2));
+        assert(rec.filter == "PASS");
+    }
+    {
+        auto vcf = VCFReader(buildPath(dirName(dirName(dirName(dirName(__FILE__)))),"htslib","test","tabix","vcf_file.vcf"));
+        auto vcfw = VCFWriter("/tmp/test_vcf.bcf", vcf.vcfhdr, VCFWriterTypes.UBCF);
+        
+        vcfw.writeHeader;
+        foreach(rec;vcf) {
+            vcfw.writeRecord(rec);
+        }
+        destroy(vcfw);
+    }
+    {
+        auto vcf = VCFReader("/tmp/test_vcf.bcf");
+        assert(vcf.count == 14);
+        vcf = VCFReader("/tmp/test_vcf.bcf");
+        
+        VCFRecord rec = vcf.front;
+        assert(rec.chrom == "1");
+        assert(rec.pos == 3000149);
+        assert(rec.refAllele == "C");
+        assert(rec.altAllelesAsArray == ["T"]);
+        assert(rec.allelesAsArray == ["C","T"]);
+        assert(approxEqual(rec.qual,59.2));
+        assert(rec.filter == "PASS");
+    }
+    {
+        auto vcf = VCFReader(buildPath(dirName(dirName(dirName(dirName(__FILE__)))),"htslib","test","tabix","vcf_file.vcf"));
+        auto vcfw = VCFWriter("/tmp/test_vcf.vcf.gz", vcf.vcfhdr, VCFWriterTypes.VCF);
+        
+        vcfw.writeHeader;
+        foreach(rec;vcf) {
+            vcfw.writeRecord(rec);
+        }
+        destroy(vcfw);
+    }
+    {
+        auto vcf = VCFReader("/tmp/test_vcf.vcf.gz");
+        assert(vcf.count == 14);
+        vcf = VCFReader("/tmp/test_vcf.vcf.gz");
+        
+        VCFRecord rec = vcf.front;
+        assert(rec.chrom == "1");
+        assert(rec.pos == 3000149);
+        assert(rec.refAllele == "C");
+        assert(rec.altAllelesAsArray == ["T"]);
+        assert(rec.allelesAsArray == ["C","T"]);
+        assert(approxEqual(rec.qual,59.2));
+        assert(rec.filter == "PASS");
+    }
 }

--- a/source/dhtslib/vcf/writer.d
+++ b/source/dhtslib/vcf/writer.d
@@ -117,6 +117,15 @@ struct VCFWriter
                 // but overcomitting by 1 thread (i.e., passing totalCPUs) buys an extra 3% on my 2-core 2013 Mac
                 hts_set_threads(this.fp, totalCPUs);
             }
+        } else if (extra_threads > 0)
+        {
+            if ((extra_threads + 1) > totalCPUs)
+                hts_log_warning(__FUNCTION__, "More threads requested than CPU cores detected");
+            hts_set_threads(this.fp, extra_threads);
+        }
+        else if (extra_threads == 0)
+        {
+            hts_log_debug(__FUNCTION__, "Zero extra threads requested");
         }
 
         static if(is(H == VCFHeader*)) { this.vcfhdr      = VCFHeader( bcf_hdr_dup(header.hdr) ); }


### PR DESCRIPTION
 - Added `Genotype` and `GT` structs to aid in conversion of VCF "GT" format data to `string`. 
    - Should also allow for modification as it is a slice to the backing format data
 - Added ability to specify output type via VCFWriter
 - Added multithreading support for `VCFReader`, `VCFWriter`, and `TabixIndexedFile`
 - Fixes
     - #116 
     - #124
     - #117 

Let me know what you think and if there is anything else I should add in.