### PR TITLE
HtslibFile and HtslibIterator

### DIFF
--- a/source/dhtslib/file/file.d
+++ b/source/dhtslib/file/file.d
@@ -1,0 +1,679 @@
+module dhtslib.file.file;
+
+import core.stdc.stdio : SEEK_SET;
+
+import std.stdio;
+import std.string : toStringz, fromStringz;
+import std.utf : toUTFz;
+import std.traits : isSomeString;
+import std.algorithm : map;
+import std.array : array;
+
+import dhtslib.memory;
+import dhtslib.file.iterator;
+import dhtslib : initKstring;
+import htslib;
+
+enum HtslibFileFormatMode
+{
+    Binary = 'b',
+    Cram = 'c',
+    Gzip = 'g',
+    Uncompressed = 'u',
+    Bgzf = 'z',
+    ZlibCompress0 = '0',
+    ZlibCompress1 = '1',
+    ZlibCompress2 = '2',
+    ZlibCompress3 = '3',
+    ZlibCompress4 = '4',
+    ZlibCompress5 = '5',
+    ZlibCompress6 = '6',
+    ZlibCompress7 = '7',
+    ZlibCompress8 = '8',
+    ZlibCompress9 = '9',
+}
+
+
+/** 
+ * Some shortcut mode strings for different file types
+ * As a reminder:
+ *      b  binary format (BAM, BCF, etc) rather than text (SAM, VCF, etc)
+        c  CRAM format
+        g  gzip compressed
+        u  uncompressed
+        z  bgzf compressed
+        [0-9]  zlib compression level
+ */
+enum HtslibFileWriteMode
+{
+    Bam             = "wb",
+    Cram            = "wc",
+    Sam             = "w",
+    UncompressedBam = "wb0",
+    GzippedSam      = "wg",
+    BgzippedSam     = "wz",
+
+    Bcf             = "wb",
+    UncompressedBcf = "wb0",
+    Vcf             = "w",
+    GzippedVcf      = "wg",
+    BgzippedVcf     = "wz",
+
+    Text            = "w",
+    GzippedText     = "wg",
+    BgzippedText    = "wz",
+    
+}
+
+/** 
+ * HtslibFile is an abstraction for htslib's htsFile using dhtslib.memory for reference counting.
+ * 
+ * Ideally this struct and its methods can replace file io across dhtslib through a 
+ * standard interface. It can also centralize the ability to duplicate a file so that 
+ * it can be iterated several times. It pairs with HtslibIterator.
+ */
+struct HtslibFile
+{
+    /// dhtslib.memory htsFile* rc wrapper
+    /// File pointer
+    HtsFile fp; 
+
+    /// D File if used
+    File f;
+
+    /// dhtslib.memory kstring_t rc wrapper
+    /// Since we need the filename as a null terminated string anyway
+    /// just use kstring
+    Kstring fn;
+
+    char[] mode;
+
+    /// SAM/BAM/CRAM index 
+    HtsIdx idx;
+
+    /// SAM/BAM/CRAM header
+    BamHdr bamHdr;
+    /// BCF/VCF header
+    BcfHdr bcfHdr;
+    /// text header
+    Kstring textHdr;
+
+    /// Tabix index 
+    Tbx tbx;
+
+    /// is file end reached?
+    bool eof;
+
+    /// offset of file after header
+    /// if it has been loaded 
+    off_t headerOffset = -1;
+
+    /// allow HtslibFile to be used as 
+    /// underlying ptr type
+    alias getFilePtr this;
+
+    /// get underlying file pointer wrapper
+    @property nothrow pure @nogc
+    ref inout(HtsFile) getFilePtr() inout return
+    {
+        return this.fp;
+    }
+
+    /// File or string ctor
+    this(T)(T f)
+    if ((isSomeString!T || is(T == File)))
+    {
+        this(f, "r");
+    }
+
+    /// File or string ctor with mode
+    this(T1, T2)(T1 f, T2 mode)
+    if ((isSomeString!T1 || is(T1 == File)) && (isSomeString!T2 || is(T2 == HtslibFileWriteMode)))
+    {
+        this.mode = mode.dup ~ '\0';
+        // open file
+        static if (isSomeString!T1)
+        {
+            this.fn = Kstring(initKstring());
+            ks_initialize(this.fn);
+            kputsn(f.ptr, f.length, this.fn);
+            this.fp = HtsFile(hts_open(this.fn.s, this.mode.ptr));
+        }
+        else static if (is(T1 == File))
+        {
+            this.fn = Kstring(initKstring());
+            ks_initialize(this.fn);
+            kputsn(f.name.ptr, f.name.length, this.fn);
+
+            auto hf = hdopen(f.fileno, m.ptr);
+            this.fp = HtsFile(hts_hopen(hf, this.fn.s, m.ptr));
+        }
+        else static assert(0);
+    }
+
+    /// Duplicate the file with the same offset
+    HtslibFile dup()
+    {
+        // open a new file
+        auto filename = fromStringz(this.fn.s).idup;
+        auto newFile = HtslibFile(filename, this.mode);
+
+        // seek to the current offset
+        newFile.seek(this.tell);
+
+        // copy internal fields
+        newFile.idx = this.idx;
+        newFile.bamHdr = this.bamHdr;
+        newFile.bcfHdr = this.bcfHdr;
+        newFile.textHdr = this.textHdr;
+        newFile.tbx = this.tbx;
+        newFile.eof = this.eof;
+        newFile.headerOffset = this.headerOffset;
+        return newFile;
+    }
+
+    /// set extra multithreading
+    void setExtraThreads(int extra)
+    {
+        hts_set_threads(this.fp, extra);
+    }
+
+    /// get file offset
+    off_t tell()
+    {
+        if(this.fp.is_bgzf) return bgzf_tell(this.fp.fp.bgzf);
+        else return htell(this.fp.fp.hfile);
+    }
+
+    /// seek to offset in file
+    void seek(long loc)
+    {
+        long err;
+        if(this.fp.is_bgzf) err = bgzf_seek(this.fp.fp.bgzf, loc, SEEK_SET);
+        else err = hseek(this.fp.fp.hfile, loc, SEEK_SET);
+        if(err < 0) hts_log_error(__FUNCTION__, "Error seeking htsFile");
+    }
+
+    /// reset file reading
+    void reset()
+    {
+        this.seek(0);
+    }
+
+    /// reset file reading
+    void resetToFirstRecord()
+    {
+        if(headerOffset != -1)
+            this.seek(headerOffset);
+        else {
+            hts_log_error(__FUNCTION__, "Cannot resetToFirstRecord, header offset unknown");
+            hts_log_error(__FUNCTION__, "Has the header been loaded?");
+        }
+    }
+
+    /// Read a SAM/BAM header, VCF/BCF header, or text header and internally store it
+    void loadHeader(char commentChar = '#')
+    {
+        switch(this.fp.format.format){
+            case htsExactFormat.sam:
+            case htsExactFormat.bam:
+            case htsExactFormat.cram:
+                this.loadHeader!BamHdr(commentChar);
+                break;
+            case htsExactFormat.vcf:
+            case htsExactFormat.bcf:
+                this.loadHeader!BcfHdr(commentChar);    
+                break;
+            default:
+                this.loadHeader!Kstring(commentChar);
+        }
+    }
+
+    /// Read a SAM/BAM header, VCF/BCF header, or text header and internally store it
+    void loadHeader(T)(char commentChar)
+    if(is(T == BamHdr) || is(T == BcfHdr) || is(T == Kstring))
+    {
+        static if(is(T == BamHdr)){
+            this.bamHdr = BamHdr(sam_hdr_read(this.fp));
+        }
+        else static if(is(T == BcfHdr)){
+            this.bcfHdr = BcfHdr(bcf_hdr_read(this.fp));
+        }
+        else static if(is(T == Kstring)){
+            // parse header from a text file
+            this.textHdr = Kstring(initKstring);
+            ks_initialize(this.textHdr);
+
+            auto ks = Kstring(initKstring);
+            ks_initialize(ks);
+
+            // peek at first char, if commentChar (#)
+            // save the line and repeat
+            if(this.fp.is_bgzf){
+                
+                while(true){
+                    if(cast(char) bgzf_peek(this.fp.fp.bgzf) == commentChar){
+                        hts_getline(this.fp, cast(int)'\n', ks);
+                        kputs(ks.s, this.textHdr);
+                        kputc(cast(int)'\n', this.textHdr);
+                    } else break;
+                }
+            }else{
+                while(true){
+                    char c;
+                    hpeek(this.fp.fp.hfile, &c, 1);
+                    if(c  == commentChar){
+                        hts_getline(this.fp, cast(int)'\n', ks);
+                        kputs(ks.s, this.textHdr);
+                        kputc(cast(int)'\n', this.textHdr);
+                    } else break;
+                }
+                this.textHdr.l--;
+                kputc(cast(int)'\0', this.textHdr);
+            }
+        }
+        // set header offset
+        this.headerOffset = this.tell;
+    }
+
+    /// set header for a HtlsibFile 
+    void setHeader(T)(T hdr)
+    if(is(T == BamHdr) || is(T == BcfHdr))
+    {
+        static if(is(T == BamHdr))
+            this.bamHdr = hdr;
+        else static if(is(T == BcfHdr))
+            this.bcfHdr = hdr;
+        else static assert(0);
+    }
+
+    /// write internally stored header
+    void writeHeader()
+    {
+        assert(this.bamHdr.initialized || this.bcfHdr.initialized);
+        assert(!(this.bamHdr.initialized && this.bcfHdr.initialized));
+        assert((this.bamHdr.initialized && this.bamHdr.getRef != null) 
+            || (this.bcfHdr.initialized && this.bcfHdr.getRef != null));
+        int err;
+        if(this.bamHdr.initialized)
+            err = sam_hdr_write(this.fp, this.bamHdr);
+        else
+            err = bcf_hdr_write(this.fp, this.bcfHdr);
+        if(err < 0) hts_log_error(__FUNCTION__, "Error writing SAM/BAM/VCF/BCF header");
+    }
+
+    /// load BAM/BCF index
+    HtsIdx loadHtsIndex()
+    {
+        if(this.fp.format.format == htsExactFormat.bam || this.fp.format.format == htsExactFormat.cram)
+            this.idx = HtsIdx(sam_index_load(this.fp, cast(const(char)*)this.fn.s));
+        else if(this.fp.format.format == htsExactFormat.bcf)
+            this.idx = HtsIdx(bcf_index_load(cast(const(char)*)this.fn.s));
+        return this.idx;
+    }
+
+    /// load SAM/BAM index from filename
+    HtsIdx loadHtsIndex(string idxFile)
+    {
+        if(this.fp.format.format == htsExactFormat.bam || this.fp.format.format == htsExactFormat.cram)
+            this.idx = HtsIdx(sam_index_load2(this.fp, this.fn.s, toStringz(idxFile)));
+        else if(this.fp.format.format == htsExactFormat.bcf)
+            this.idx = HtsIdx(bcf_index_load2(this.fn.s, toStringz(idxFile)));
+        return this.idx;
+    }
+
+    /// load tabix index
+    Tbx loadTabixIndex()
+    {
+        this.tbx = Tbx(tbx_index_load(this.fn.s));
+        return this.tbx;
+    }
+
+    /// load tabix index from file
+    Tbx loadTabixIndex(T)(T idxFile)
+    if(isSomeString!T)
+    {
+        this.tbx = Tbx(tbx_index_load2(this.fn.s, toStringz(idxFile)));
+        return this.tbx;
+    }
+
+    /// Query htsFile with tid, start, and end
+    /// returns an HtslibIterator that has type T
+    /// requires index be loaded first
+    /// can use Tabix index or BAI/CSI index
+    auto query(T)(int tid, long beg, long end)
+    if(is(T == Bam1) || is(T == Bcf1) || is(T == Kstring))
+    {
+        // if T == Kstring
+        // we assume using tabix index
+        static if(is(T == Kstring)){
+            if(this.tbx != null){
+                auto itr = HtsItr(tbx_itr_queryi(this.tbx, tid, beg, end));
+                return HtslibIterator!Kstring(this, itr);
+            }else{
+                throw new Exception("No TABIX index is loaded");
+            }
+        }else{
+            // BAI/CSI Index
+            if(this.idx != null){
+                static if(is(T == Bam1)){
+                    auto itr = HtsItr(sam_itr_queryi(this.idx, tid, beg, end));
+                    return HtslibIterator!Bam1(this, itr);
+                }else static if(is(T == Bcf1)){
+                    auto itr = HtsItr(hts_itr_query(this.idx, tid, beg, end, &bcf_readrec));
+                    return HtslibIterator!Bcf1(this, itr);
+                }
+            // Tabix Index
+            }else if(this.tbx != null){
+                static if(is(T == Bam1)){
+                    auto itr = HtsItr(tbx_itr_queryi(this.tbx, tid, beg, end));
+                    return HtslibIterator!Bam1(this, itr);
+                }else static if(is(T == Bcf1)){
+                    auto itr = HtsItr(tbx_itr_queryi(this.tbx, tid, beg, end));
+                    return HtslibIterator!Bcf1(this, itr);
+                }
+            }else{
+                throw new Exception("No TABIX/BAI/CSI index is loaded");
+            }
+        }
+        
+        
+    }
+
+    /// Query htsFile with string region
+    /// returns an HtslibIterator that has type T
+    /// requires index and header be loaded first
+    /// can use Tabix index or BAI/CSI index
+    auto query(T)(string region)
+    if(is(T == Bam1) || is(T == Bcf1))
+    {
+        // BAI/CSI Index
+        if(this.idx != null){
+            static if(is(T == Bam1)){
+                auto itr = HtsItr(sam_itr_querys(this.idx, this.bamHdr, toStringz(region)));
+                return HtslibIterator!Bam1(this, itr);
+            }else static if(is(T == Bcf1)){
+                auto itr = HtsItr(bcf_itr_querys(this.idx, this.bcfHdr, toStringz(region)));
+                return HtslibIterator!Bcf1(this, itr);
+            }
+        // Tabix Index
+        }else if(this.tbx != null){
+            static if(is(T == Bam1)){
+                auto itr = HtsItr(tbx_itr_querys(this.tbx, toStringz(region)));
+                return HtslibIterator!Bam1(this, itr);
+            }else static if(is(T == Bcf1)){
+                auto itr = HtsItr(tbx_itr_querys(this.tbx, toStringz(region)));
+                return HtslibIterator!Bcf1(this, itr);
+            }else static if(is(T == Kstring)){
+                auto itr = HtsItr(tbx_itr_querys(this.tbx, toStringz(region)));
+                return HtslibIterator!Kstring(this, itr);
+            }
+        }else{
+            throw new Exception("No TABIX/BAI/CSI index is loaded");
+        }
+    }
+
+    /// Query htsFile with array of regions
+    /// returns an HtslibIterator that has type Bam1
+    /// requires index and header be loaded first
+    auto query(string[] regions)
+    {
+        auto cQueries = regions.map!(toUTFz!(char *)).array;
+
+        assert(this.idx.getRef != null);
+        auto itr = HtsItr(sam_itr_regarray(this.idx, this.bamHdr, cQueries.ptr, cast(int)regions.length));
+        return HtslibIterator!Bam1(this, itr);
+    }
+
+    /// iterate over all records in a file
+    /// returns a HtslibIterator
+    auto byRecord(T)()
+    if(is(T == Bam1) || is(T == Bcf1) || is(T == Kstring))
+    {
+        return HtslibIterator!T(this);
+    }
+
+    /// write SAM/BAM/VCF/BCF record, string, or ubyte data
+    /// requires the header be loaded if writing SAM/BAM/VCF/BCF record
+    void write(T)(T rec)
+    if(isSomeString!T || is(T == Bam1) || is(T == Bcf1) || is(T == Kstring) || is(T == ubyte[]))
+    {
+        long err;
+        static if(is(T == Bam1)){
+            err = sam_write1(this.fp, this.bamHdr, rec);
+        }else static if(is(T == Bcf1)){
+            err = bcf_write(this.fp, this.bcfHdr, rec);
+        }else static if(isSomeString!T || is(T == ubyte[])){
+            if(this.fp.is_bgzf) err = bgzf_write(this.fp.fp.bgzf, rec.ptr, rec.length);
+            else err = hwrite(this.fp.fp.hfile, rec.ptr, rec.length);
+        }else static if(is(T == Kstring)){
+            if(this.fp.is_bgzf) err = bgzf_write(this.fp.fp.bgzf, rec.s, rec.l);
+            else err = hwrite(this.fp.fp.hfile, rec.s, rec.l);
+        }else static assert(0);
+        if(err < 0) hts_log_error(__FUNCTION__, "Error writing SAM/BAM/VCF/BCF record, string, or ubyte data");
+    }
+
+    /// write a string with a newline appended
+    void writeln(T)(T rec)
+    if(isSomeString!T)
+    {
+        rec = rec ~ '\n';
+        write(rec);
+    }
+
+    /// read a BAM/SAM/BCF/VCF record
+    auto readRecord(T)()
+    if(is(T == Bam1) || is(T == Bcf1) || is(T == Kstring))
+    {
+        long err;
+        static if(is(T == Bam1)){
+            assert(this.bamHdr.initialized && this.bamHdr.getRef != null);
+            auto rec = bam_init1;
+            err = sam_read1(this.fp, this.bamHdr, rec);
+        }
+        else static if(is(T == Bcf1)){
+            assert(this.bcfHdr.initialized && this.bcfHdr.getRef != null);
+            auto rec = bcf_init;
+            err = bcf_read(this.fp, this.bcfHdr, rec);
+        }else static if(is(T == Kstring)){
+            auto rec = initKstring;
+            ks_initialize(rec);
+            err = hts_getline(this.fp, cast(int)'\n', rec);
+        }
+        if(err < -1) hts_log_error(__FUNCTION__, "Error reading Bam/Bcf record");
+        else if(err == -1) eof = true;
+        return T(rec);
+    }
+
+}
+
+debug(dhtslib_unittest) unittest
+{
+    hts_log_info(__FUNCTION__, "Testing HtslibFile text reading and writing");
+    {
+        auto f = HtslibFile("/tmp/htslibfile.test.txt", HtslibFileWriteMode.Text);
+        f.writeln("hello");
+        f.writeln("test");
+
+        f = HtslibFile("/tmp/htslibfile.test.txt.gz", HtslibFileWriteMode.GzippedText);
+        f.writeln("hello");
+        f.writeln("test");
+
+        f = HtslibFile("/tmp/htslibfile.test.txt.bgz", HtslibFileWriteMode.BgzippedText);
+        f.writeln("hello");
+        f.writeln("test");
+
+        f = HtslibFile("/tmp/htslibfile.test.txt.9gz", "w9");
+        f.writeln("hello");
+        f.writeln("test");
+    }
+    {
+        auto f = HtslibFile("/tmp/htslibfile.test.txt");
+        assert(fromStringz(f.readRecord!Kstring.s) == "hello");
+        assert(fromStringz(f.readRecord!Kstring.s) == "test");
+
+        f = HtslibFile("/tmp/htslibfile.test.txt.gz");
+        assert(fromStringz(f.readRecord!Kstring.s) == "hello");
+        assert(fromStringz(f.readRecord!Kstring.s) == "test");
+
+        f = HtslibFile("/tmp/htslibfile.test.txt.bgz");
+        assert(fromStringz(f.readRecord!Kstring.s) == "hello");
+        assert(fromStringz(f.readRecord!Kstring.s) == "test");
+
+        f = HtslibFile("/tmp/htslibfile.test.txt.9gz");
+        assert(fromStringz(f.readRecord!Kstring.s) == "hello");
+        assert(fromStringz(f.readRecord!Kstring.s) == "test");
+
+    }
+    {
+        auto f = HtslibFile("/tmp/htslibfile.test.txt.gz");
+        assert(fromStringz(f.readRecord!Kstring.s) == "hello");
+        assert(fromStringz(f.readRecord!Kstring.s) == "test");
+    }
+    {
+        auto f = HtslibFile("/tmp/htslibfile.test.txt");
+        assert(f.byRecord!Kstring.map!(x=> fromStringz(x.s).idup).array == ["hello", "test"] );
+    }
+}
+
+debug(dhtslib_unittest) unittest
+{
+    hts_log_info(__FUNCTION__, "Testing HtslibFile SAM/BAM reading and writing");
+    import std.path:buildPath,dirName;
+    auto fn = buildPath(dirName(dirName(dirName(dirName(__FILE__)))),"htslib","test","range.bam");
+    {
+        auto f = HtslibFile(fn);
+        f.loadHeader;
+        auto h = f.bamHdr;
+        auto read = f.readRecord!Bam1();
+
+        f = HtslibFile("/tmp/htslibfile.test.sam", HtslibFileWriteMode.Sam);
+        f.setHeader(h);
+        f.writeHeader;
+        f.write(read);
+        
+        f = HtslibFile("/tmp/htslibfile.test.bam", HtslibFileWriteMode.Bam);
+        f.setHeader(h);
+        f.writeHeader;
+        f.write(read);
+
+        f = HtslibFile("/tmp/htslibfile.test.ubam", HtslibFileWriteMode.UncompressedBam);
+        f.setHeader(h);
+        f.writeHeader;
+        f.write(read);
+
+        f = HtslibFile("/tmp/htslibfile.test.sam.gz", HtslibFileWriteMode.GzippedSam);
+        f.setHeader(h);
+        f.writeHeader;
+        f.write(read);
+
+        f = HtslibFile("/tmp/htslibfile.test.sam.bgz", HtslibFileWriteMode.BgzippedSam);
+        f.setHeader(h);
+        f.writeHeader;
+        f.write(read);
+
+    }
+    {
+
+        auto f = HtslibFile("/tmp/htslibfile.test.sam");
+        f.loadHeader;
+        auto h = f.bamHdr;
+        auto read = f.readRecord!Bam1();
+        assert(fromStringz(bam_get_qname(read)) == "HS18_09653:4:1315:19857:61712");
+        
+        f = HtslibFile("/tmp/htslibfile.test.bam");
+        f.loadHeader;
+        h = f.bamHdr;
+        read = f.readRecord!Bam1();
+        assert(fromStringz(bam_get_qname(read)) == "HS18_09653:4:1315:19857:61712");
+
+        f = HtslibFile("/tmp/htslibfile.test.ubam");
+        f.loadHeader;
+        h = f.bamHdr;
+        read = f.readRecord!Bam1();
+        assert(fromStringz(bam_get_qname(read)) == "HS18_09653:4:1315:19857:61712");
+
+        f = HtslibFile("/tmp/htslibfile.test.sam.gz");
+        f.loadHeader;
+        h = f.bamHdr;
+        read = f.readRecord!Bam1();
+        assert(fromStringz(bam_get_qname(read)) == "HS18_09653:4:1315:19857:61712");
+
+        f = HtslibFile("/tmp/htslibfile.test.sam.bgz");
+        f.loadHeader;
+        h = f.bamHdr;
+        read = f.readRecord!Bam1();
+        assert(fromStringz(bam_get_qname(read)) == "HS18_09653:4:1315:19857:61712");
+    }
+}
+
+debug(dhtslib_unittest) unittest
+{
+    hts_log_info(__FUNCTION__, "Testing HtslibFile BCF reading and writing");
+    import std.path:buildPath,dirName;
+    auto fn = buildPath(dirName(dirName(dirName(dirName(__FILE__)))),"htslib","test","tabix","vcf_file.vcf.gz");
+    {
+        auto f = HtslibFile(fn);
+        f.loadHeader;
+        auto h = f.bcfHdr;
+        auto read = f.readRecord!Bcf1();
+
+        f = HtslibFile("/tmp/htslibfile.test.vcf", HtslibFileWriteMode.Vcf);
+        f.setHeader(h);
+        f.writeHeader;
+        f.write(read);
+        
+        f = HtslibFile("/tmp/htslibfile.test.bcf", HtslibFileWriteMode.Bcf);
+        f.setHeader(h);
+        f.writeHeader;
+        f.write(read);
+
+        f = HtslibFile("/tmp/htslibfile.test.ubcf", HtslibFileWriteMode.UncompressedBcf);
+        f.setHeader(h);
+        f.writeHeader;
+        f.write(read);
+
+        f = HtslibFile("/tmp/htslibfile.test.vcf.gz", HtslibFileWriteMode.GzippedVcf);
+        f.setHeader(h);
+        f.writeHeader;
+        f.write(read);
+
+        f = HtslibFile("/tmp/htslibfile.test.vcf.bgz", HtslibFileWriteMode.BgzippedVcf);
+        f.setHeader(h);
+        f.writeHeader;
+        f.write(read);
+
+    }
+    {
+
+        auto f = HtslibFile("/tmp/htslibfile.test.vcf");
+        f.loadHeader;
+        auto h = f.bcfHdr;
+        auto read = f.readRecord!Bcf1();
+        assert(read.pos == 3000149);
+        
+        f = HtslibFile("/tmp/htslibfile.test.bcf");
+        f.loadHeader;
+        h = f.bcfHdr;
+        read = f.readRecord!Bcf1();
+        assert(read.pos == 3000149);
+
+        f = HtslibFile("/tmp/htslibfile.test.ubcf");
+        f.loadHeader;
+        h = f.bcfHdr;
+        read = f.readRecord!Bcf1();
+        assert(read.pos == 3000149);
+
+        f = HtslibFile("/tmp/htslibfile.test.vcf.gz");
+        f.loadHeader;
+        h = f.bcfHdr;
+        read = f.readRecord!Bcf1();
+        assert(read.pos == 3000149);
+
+        f = HtslibFile("/tmp/htslibfile.test.vcf.bgz");
+        f.loadHeader;
+        h = f.bcfHdr;
+        read = f.readRecord!Bcf1();
+        assert(read.pos == 3000149);
+    }
+}

--- a/source/dhtslib/file/iterator.d
+++ b/source/dhtslib/file/iterator.d
@@ -1,0 +1,377 @@
+module dhtslib.file.iterator;
+
+import core.stdc.stdlib;
+import core.stdc.string;
+
+import dhtslib.memory;
+import dhtslib.file.file;
+import dhtslib.util;
+import htslib;
+
+/** 
+ * HtslibIterator is an abstraction for htslib's hts_itr_t using dhtslib.memory for reference counting.
+ * HtslibIterator can be used to iterate VCF/BCF/SAM/BAM/Text files using a BAI/CSI/TBX index
+ * or by simply iterating the file.
+ * 
+ * This struct adapts htslib's iterators into ForwardRange. It is paired with 
+ * and relies on HtslibFile. 
+ */
+struct HtslibIterator(T)
+if(is(T == Bam1) || is(T == Bcf1) || is(T == Kstring))
+{
+    HtslibFile f;               /// HtslibFile
+    HtsItr itr;                 /// refcounted hts_itr_t
+    T rec;                      /// refcounted bam1_t, bcf1_t, or kstring_t
+    private Kstring line;
+    private bool is_itr;        /// Using an Itr or just calling *_read functions
+    private bool initialized;   /// Is the range initialized
+    /// htslib read function return value
+    /// -1 on eof, < -1 on err
+    /// must be pointer to keep range updated when blitted
+    private int * r; 
+
+    /// ctor using only HtslibFile
+    /// without an iterator
+    this(HtslibFile f)
+    {
+        this.r = new int(0);
+        this.f = f;
+        static if(is(T == Bam1)){
+            rec = Bam1(bam_init1);
+        }else static if(is(T == Bcf1)){
+            rec = Bcf1(bcf_init);
+        }else static if(is(T == Kstring)){
+            rec = Kstring(initKstring);
+            ks_initialize(rec);
+        }
+        this.line = Kstring(initKstring);
+        ks_initialize(this.line);
+        this.empty;
+    }
+
+    /// ctor using an HtslibFile and an iterator
+    this(HtslibFile f, HtsItr itr)
+    {
+        this.is_itr = true;
+        this.itr = itr;
+        this(f);
+    }
+
+    /// Duplicate the iterator
+    /// must fully duplicate hts_itr_t
+    HtslibIterator dup()
+    {
+
+        HtslibIterator newItr;
+        // dup file
+        newItr.f = this.f.dup;
+
+        // set private values
+        newItr.r = new int(*this.r);
+        newItr.initialized = this.initialized;
+        newItr.is_itr = this.is_itr;
+
+        // duplicate current record
+        static if(is(T == Bam1)){
+            newItr.rec = Bam1(bam_dup1(this.rec));
+        }else static if(is(T == Bcf1)){
+            newItr.rec = Bcf1(bcf_dup(this.rec));
+        }else static if(is(T == Kstring)){
+            auto ks = Kstring(initKstring);
+            ks_initialize(ks);
+            kputs(this.rec.s, ks);
+            newItr.rec = ks;
+        }
+        auto ks2 = Kstring(initKstring);
+        ks_initialize(ks2);
+        kputs(ks_c_str(this.line), ks2);
+        newItr.line = ks2;
+
+        // if itr we need to deep copy it
+        if(this.is_itr){
+            // init
+            auto newHtsItr = cast(hts_itr_t *) malloc(hts_itr_t.sizeof);
+
+            // bulk copy data
+            *newHtsItr = *itr;
+
+            // initialize and copy region list
+            // if it is not null
+            if(newHtsItr.reg_list != null){
+
+                // initialize the region lists
+                newHtsItr.reg_list = cast(hts_reglist_t *) malloc(itr.n_reg * hts_reglist_t.sizeof);
+                newHtsItr.reg_list[0 .. newHtsItr.n_reg] = itr.reg_list[0 .. itr.n_reg];
+
+                // for each list
+                for(auto i=0; i < newHtsItr.n_reg; i++)
+                {
+                    // copy all intervals
+                    newHtsItr.reg_list[i].intervals = cast(hts_pair_pos_t *) malloc(itr.reg_list[i].count * hts_pair_pos_t.sizeof);
+                    newHtsItr.reg_list[i].intervals[0 .. newHtsItr.reg_list[i].count] = itr.reg_list[i].intervals[0 .. itr.reg_list[i].count];
+
+                    // copy region c string
+                    // if not null
+                    if(itr.reg_list[i].reg){
+                        newHtsItr.reg_list[i].reg = cast(char *) malloc(strlen(itr.reg_list[i].reg) + 1);
+                        memcpy(cast(void*)(newHtsItr.reg_list[i].reg),itr.reg_list[i].reg, strlen(itr.reg_list[i].reg) + 1);
+                    }
+                }
+            }
+
+            // initialize and copy bins list
+            newHtsItr.bins.a = cast(int *) malloc(itr.bins.m * int.sizeof);
+            assert(newHtsItr.bins.m >= newHtsItr.bins.n);
+            newHtsItr.bins.a[0 .. newHtsItr.bins.m] = itr.bins.a[0 .. itr.bins.m];
+
+            // initialize and copy off list
+            newHtsItr.off = cast(hts_pair64_max_t *) malloc(itr.n_off * hts_pair64_max_t.sizeof);
+            newHtsItr.off[0 .. newHtsItr.n_off] = itr.off[0 .. itr.n_off];
+            
+            // set new itr
+            newItr.itr = HtsItr(newHtsItr);
+        }else{
+            newItr.itr = this.itr;
+        }
+        
+        return newItr;
+    }
+
+    /// Get front of the iterator, returns  Bam1, Bcf1, or Kstring
+    /// Backing bam1_t, bcf1_t, kstring_t is re-used 
+    /// If you keep the result around it should be duplicated
+    T front()
+    {
+        return rec;
+    }
+
+    /// popFront to move range forward
+    /// is destructive
+    void popFront()
+    {
+        if(!is_itr){
+            static if(is(T == Bam1)){
+                assert(this.f.bamHdr.initialized && this.f.bamHdr.getRef);
+                *this.r = sam_read1(this.f.fp, this.f.bamHdr, rec);
+            }
+            else static if(is(T == Bcf1)){
+                assert(this.f.bcfHdr.initialized && this.f.bcfHdr.getRef);
+                *this.r = bcf_read(this.f.fp, this.f.bcfHdr, rec);
+            }else static if(is(T == Kstring)){
+                *this.r = hts_getline(this.f.fp, cast(int)'\n', rec);
+            }
+        }else{
+            if (itr.multi)
+                *this.r = hts_itr_multi_next(f.fp, itr, rec.getRef);
+            else{
+                if(f.idx != null)
+                    *this.r = hts_itr_next(f.fp.is_bgzf ? f.fp.fp.bgzf : null, itr, rec.getRef, f.fp);
+                else if(f.tbx != null){
+                    static if(is(T == Kstring))
+                        *this.r = hts_itr_next(f.fp.is_bgzf ? f.fp.fp.bgzf : null, itr, rec.getRef, f.tbx);
+                    else {
+                        *this.r = hts_itr_next(f.fp.is_bgzf ? f.fp.fp.bgzf : null, itr, this.line.getRef, f.tbx);
+                        static if(is(T == Bam1))
+                            *this.r = sam_parse1(this.line, this.f.bamHdr, this.rec);
+                        else static if(is(T == Bcf1))
+                            *this.r = vcf_parse(this.line, this.f.bcfHdr, this.rec);
+                        ks_clear(this.line);
+                    }
+                    
+                }
+                else{
+                    *r = -2;
+                    hts_log_error(__FUNCTION__, "Neither tabix nor bai/csi index are loaded");
+                }
+                    
+            }
+        }
+    }
+
+    /// InputRange interface
+    @property bool empty()
+    {
+        // TODO, itr.finished shouldn't be used
+        if (!this.initialized) {
+            this.popFront();
+            this.initialized = true;
+        }
+        if(!is_itr){
+            return *r < 0 ? true : false;
+        }else{
+            assert(this.itr.initialized && this.itr.getRef);
+            return (*r < 0 || itr.finished) ? true : false;
+        }
+    }
+    
+    /// Needed to be ForwardRange
+    typeof(this) save()
+    {
+        return this.dup;
+    }
+}
+debug(dhtslib_unittest) unittest
+{
+    import std.path:buildPath,dirName;
+    import std.algorithm: count;
+    import std.string: fromStringz;
+    hts_log_info(__FUNCTION__, "Testing HtslibIterator SAM/BAM reading");
+    
+    auto fn = buildPath(dirName(dirName(dirName(dirName(__FILE__)))),"htslib","test","range.bam");
+    auto f = HtslibFile(fn);
+    f.loadHeader;
+    auto read = f.readRecord!Bam1();
+    assert(fromStringz(bam_get_qname(read)) == "HS18_09653:4:1315:19857:61712");
+    
+    f.seek(0);
+    f.loadHeader;
+    assert(f.byRecord!Bam1.count == 112);
+
+    f.seek(0);
+    f.loadHeader;
+    f.loadHtsIndex;
+    assert(f.query!Bam1(0,913,914).count == 1);
+
+    f.seek(0);
+    f.loadHeader;
+    f.loadHtsIndex;
+    assert(f.query!Bam1(0,913,934).count == 2);
+
+    f.seek(0);
+    f.loadHeader;
+    f.loadHtsIndex;
+    assert(f.query!Bam1(0,913,934).count == 2);
+    assert(f.query!Bam1("CHROMOSOME_I:914-935").count == 2);
+
+    f.seek(0);
+    f.loadHeader;
+    string[] regions = ["CHROMOSOME_I:900-2000","CHROMOSOME_II:900-2000"];
+    assert(f.query(regions).count == 33);
+}
+
+debug(dhtslib_unittest) unittest
+{
+    import std.algorithm: count;
+    import std.path:buildPath,dirName;
+    hts_log_info(__FUNCTION__, "Testing HtslibIterator VCF/BCF reading");
+    auto fn = buildPath(dirName(dirName(dirName(dirName(__FILE__)))),"htslib","test","tabix","vcf_file.vcf.gz");
+    auto f = HtslibFile(fn);
+    f.loadHeader;
+    auto read = f.readRecord!Bcf1();
+    assert(read.pos == 3000149);
+
+    import std.stdio;
+    f.seek(0);
+    f.loadHeader;
+    assert(f.byRecord!Bcf1.count == 14);
+
+    f.loadTabixIndex;
+    
+    f.seek(0);
+    f.loadHeader;
+    assert(f.query!Bcf1(0, 3000149, 3000151).count == 2);
+
+    f.seek(0);
+    f.loadHeader;
+    assert(f.query!Bcf1("1:3000150-3000151").count == 2);
+}
+
+debug(dhtslib_unittest) unittest
+{
+    import std.algorithm: count;
+    import std.path:buildPath,dirName;
+    import std.string : fromStringz;
+    hts_log_info(__FUNCTION__, "Testing HtslibIterator dup");
+
+    auto fn = buildPath(dirName(dirName(dirName(dirName(__FILE__)))),"htslib","test","range.bam");
+    auto f = HtslibFile(fn);
+    f.loadHeader;
+    f.loadHtsIndex;
+    auto read = f.readRecord!Bam1();
+    assert(fromStringz(bam_get_qname(read)) == "HS18_09653:4:1315:19857:61712");
+
+    auto range1 = f.query!Bam1(0,900,2000);
+    auto range2 = range1.dup;
+    import std.stdio;
+
+    assert(range1.count == 14);
+    assert(range1.empty == true);
+    assert(range2.count == 14);
+
+    f.seek(0);
+    f.loadHeader;
+
+    range1 = f.query!Bam1(0,900,2000);
+    range1.popFront;
+    range2 = range1.dup;
+    range2.popFront;
+
+    assert(range1.count == 13);
+    assert(range1.empty == true);
+    assert(range2.count == 12);
+
+    f.seek(0);
+    f.loadHeader;
+
+    range1 = f.byRecord!Bam1();
+    range1.popFront;
+    range2 = range1.dup;
+    range2.popFront;
+
+    assert(range1.count == 111);
+    assert(range1.count == 0);
+    assert(range1.empty == true);
+    assert(range2.count == 110);
+
+    f.seek(0);
+    f.loadHeader;
+    string[] regions = ["CHROMOSOME_I:900-2000","CHROMOSOME_II:900-2000"];
+    range1 = f.query(regions);
+    range2 = range1.dup;
+    range2.popFront;
+    assert(range1.count == 33);
+    assert(range2.count == 32);
+
+    f.seek(0);
+    f.loadHeader;
+    auto f2 =  f.dup;
+    read = f.readRecord!Bam1();
+    assert(fromStringz(bam_get_qname(read)) == "HS18_09653:4:1315:19857:61712");
+    read = f2.readRecord!Bam1();
+    assert(fromStringz(bam_get_qname(read)) == "HS18_09653:4:1315:19857:61712");
+
+
+    fn = buildPath(dirName(dirName(dirName(dirName(__FILE__)))),"htslib","test","tabix","vcf_file.vcf");
+    f = HtslibFile(fn);
+    f.loadHeader;
+    auto vrange1 = f.byRecord!Bcf1();
+    vrange1.popFront;
+    auto vrange2 = vrange1.dup;
+    vrange2.popFront;
+
+    assert(vrange1.count == 13);
+    assert(vrange2.count == 12);
+
+    fn = buildPath(dirName(dirName(dirName(dirName(__FILE__)))),"htslib","test","tabix","bed_file.bed");
+    f = HtslibFile(fn);
+    f.loadHeader;
+    auto trange1 = f.byRecord!Kstring();
+    trange1.popFront;
+    auto trange2 = trange1.dup;
+    trange2.popFront;
+
+    assert(trange1.count == 14);
+    assert(trange2.count == 13);
+
+    fn = buildPath(dirName(dirName(dirName(dirName(__FILE__)))),"htslib","test","tabix","bed_file.bed.gz");
+    f = HtslibFile(fn);
+    f.loadHeader;
+    trange1 = f.byRecord!Kstring();
+    trange1.popFront;
+    trange2 = trange1.dup;
+    trange2.popFront;
+
+    assert(trange1.count == 14);
+    assert(trange2.count == 13);
+
+}

--- a/source/dhtslib/file/package.d
+++ b/source/dhtslib/file/package.d
@@ -1,0 +1,4 @@
+module dhtslib.file;
+
+public import dhtslib.file.file;
+public import dhtslib.file.iterator;


### PR DESCRIPTION
Added `HtslibFile` and `HtslibIterator`.

`HtslibFile` can read/write any htslib format, load a tabix or htslib index, load a header, and `query` the file or get all records with `byRecord` by using `HtslibIterator`. `HtslibIterator` can use an `hts_itr_t` or just the `HtslibFile` to provide a `ForwardRange` to iterate a file. The range's `front` type can be `bcf1_t`, `bam1_t`, or `kstring_t`.

This is part of an effort to isolate bugs, and unify code surrounding I/O and File iterators across `dhtslib`. All code uses `dhtslib.memory` to control memory allocation and freeing. 

These changes should help: 
 - open up some more functionality i.e . using a tabix index to query a bgzipped-sam file 
 - allow us to not have to use `TabixIndexedFile` to perform a query and then convert the string lines to `bcf1_t`s with `VCFReader`
 - `VCFReader` could have its own query methods similar to `SAMReader`. 
 -  give us more flexibility to write compressed formats. 

On branch `file_abstract` there has been more work done to convert the file readers and writers over to using `HtslibFile` and `HtslibIterator`.